### PR TITLE
Ensures all existing organization members are granted the All-repository triage role

### DIFF
--- a/.github/workflows/triage-contributors.yml
+++ b/.github/workflows/triage-contributors.yml
@@ -34,7 +34,7 @@ jobs:
             let triageRole = null;
             try {
               const { data } = await github.request('GET /orgs/{org}/organization-roles', { org });
-              triageRole = data.roles.find(r =>
+              triageRole = (data.roles || []).find(r =>
                 (r.name && r.name.toLowerCase() === 'all-repository triage') ||
                 (r.slug && r.slug.toLowerCase() === 'all-repository-triage') ||
                 /all.*triage/i.test(r.name || '')
@@ -91,31 +91,26 @@ jobs:
                   }
                 }
 
-                const currentIds = new Set(
-                  currentRoles.map(r => r.id || r.role_id).filter(Boolean)
-                );
-
-                if (currentIds.has(triageRole.id)) {
+                const hasTriage = currentRoles.some(r => (r.id || r.role_id) === triageRole.id);
+                if (hasTriage) {
                   table += `| ${username} | ➖ already has All-repo triage |\n`;
                   continue;
                 }
-
-                currentIds.add(triageRole.id);
-                const role_ids = Array.from(currentIds);
 
                 if (dryRun) {
                   table += `| ${username} | 🛑 dry-run: would assign All-repo triage |\n`;
                   continue;
                 }
 
+                // ✅ Correct endpoint
                 await github.request(
-                  'PUT /orgs/{org}/organization-roles/users/{username}',
-                  { org, username, role_ids }
+                  'PUT /orgs/{org}/organization-roles/users/{username}/{role_id}',
+                  { org, username, role_id: triageRole.id }
                 );
 
                 table += `| ${username} | ✅ assigned All-repo triage |\n`;
               } catch (e) {
-                table += `| ${username} | ❌ assignment failed: ${e.message} |\n`;
+                table += `| ${username} | ❌ assignment failed: ${e.status || ''} ${e.message} |\n`;
               }
             }
 

--- a/.github/workflows/triage-contributors.yml
+++ b/.github/workflows/triage-contributors.yml
@@ -1,0 +1,131 @@
+name: Ensure All Members Have All-Repo Triage
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'   # Weekly, 03:00 UTC on Mondays
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Simulate without changing roles'
+        required: false
+        default: 'false'
+      exclude:
+        description: 'Comma-separated usernames to exclude'
+        required: false
+        default: ''
+
+jobs:
+  enforce-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure triage role for all members
+        uses: actions/github-script@v7
+        with:
+          # Fine-grained token with org admin perms:
+          # Organization administration (Read & write)
+          github-token: ${{ secrets.ORG_INVITE }}
+          script: |
+            const org = 'armbian';
+            const dryRun = '${{ github.event.inputs["dry-run"] }}' === 'true';
+            const excludeCsv = '${{ github.event.inputs["exclude"] }}'.trim();
+            const EXCLUDE = new Set(excludeCsv ? excludeCsv.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : []);
+
+            // 1) Find the "All-repository triage" role
+            let triageRole = null;
+            try {
+              const { data: roles } = await github.request('GET /orgs/{org}/organization-roles', { org });
+              triageRole = roles.find(r =>
+                (r.name && r.name.toLowerCase() === 'all-repository triage') ||
+                (r.slug && r.slug.toLowerCase() === 'all-repository-triage') ||
+                /all.*triage/i.test(r.name || '')
+              );
+              if (!triageRole) throw new Error('Org role not found: All-repository triage');
+              core.info(`Found role: ${triageRole.name} (id=${triageRole.id})`);
+            } catch (e) {
+              core.setFailed(`Unable to list/find org roles: ${e.message}`);
+              return;
+            }
+
+            // 2) Get all members (role=member). Owners are handled separately.
+            const members = await github.paginate(github.rest.orgs.listMembers, {
+              org,
+              per_page: 100,
+              role: 'member'
+            });
+
+            // Optional: also include owners if you want (set includeOwners=true)
+            const includeOwners = false;
+            let owners = [];
+            if (includeOwners) {
+              owners = await github.paginate(github.rest.orgs.listMembers, {
+                org,
+                per_page: 100,
+                role: 'admin'
+              });
+            }
+
+            // Build final target list
+            const targets = [...members, ...owners]
+              .map(u => u.login.toLowerCase())
+              .filter(u => !EXCLUDE.has(u));
+
+            if (targets.length === 0) {
+              core.info('No eligible members to process.');
+              return;
+            }
+
+            let table = '\n| User | Action |\n|---|---|\n';
+
+            for (const username of targets) {
+              try {
+                // 3) Get current role assignments for the user so we don't overwrite them
+                let currentRoles = [];
+                try {
+                  const { data } = await github.request('GET /orgs/{org}/organization-roles/users/{username}', {
+                    org, username
+                  });
+                  currentRoles = Array.isArray(data) ? data : (data.roles || data || []);
+                } catch (e) {
+                  // Some orgs return 404 if no roles yet; that's okay.
+                  if (e.status !== 404) {
+                    table += `| ${username} | ⚠️ read roles failed: ${e.message} |\n`;
+                    continue;
+                  }
+                }
+
+                const currentIds = new Set(
+                  currentRoles
+                    .map(r => r.id || r.role_id) // accept either shape
+                    .filter(Boolean)
+                );
+
+                const alreadyHas = currentIds.has(triageRole.id);
+                if (alreadyHas) {
+                  table += `| ${username} | ➖ already has All-repo triage |\n`;
+                  continue;
+                }
+
+                // Merge: keep existing roles + add triage
+                currentIds.add(triageRole.id);
+                const role_ids = Array.from(currentIds);
+
+                if (dryRun) {
+                  table += `| ${username} | 🛑 dry-run: would assign All-repo triage |\n`;
+                  continue;
+                }
+
+                // 4) Update assignment (merge set)
+                await github.request('PUT /orgs/{org}/organization-roles/users/{username}', {
+                  org, username, role_ids
+                });
+
+                table += `| ${username} | ✅ assigned All-repo triage (merged) |\n`;
+              } catch (e) {
+                table += `| ${username} | ❌ assignment failed: ${e.message} |\n`;
+              }
+            }
+
+            await core.summary
+              .addHeading('All-repository triage enforcement')
+              .addRaw(table, true)
+              .write();

--- a/.github/workflows/triage-contributors.yml
+++ b/.github/workflows/triage-contributors.yml
@@ -1,126 +1,28 @@
-name: Ensure All Members Have All-Repo Triage
-
-on:
-  schedule:
-    - cron: '0 3 * * 1'   # Weekly
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Simulate without changing roles'
-        required: false
-        default: 'false'
-      exclude:
-        description: 'Comma-separated usernames to exclude'
-        required: false
-        default: ''
-
+name: Probe Org Roles
+on: workflow_dispatch
 jobs:
-  enforce-triage:
+  probe:
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure triage role for all members
-        uses: actions/github-script@v7
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.ORG_INVITE }}
           script: |
             const org = 'armbian';
-            const dryRun = '${{ github.event.inputs.dry_run }}' === 'true';
-            const excludeCsv = '${{ github.event.inputs.exclude }}'.trim();
-            const EXCLUDE = new Set(
-              excludeCsv ? excludeCsv.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : []
-            );
-
-            // 1) Find the "All-repository triage" role
-            let triageRole = null;
+            // Show who we are
+            const me = await github.request('GET /user');
+            core.info(`Token user: ${me.data.login}`);
+            // Confirm ownership level (owner vs member)
+            try {
+              const m = await github.request('GET /user/memberships/orgs/{org}', { org });
+              core.info(`Org role: ${m.data.role}`); // should be 'admin' for owners
+            } catch (e) {
+              core.warning(`Membership check failed: ${e.message}`);
+            }
+            // List roles
             try {
               const { data: roles } = await github.request('GET /orgs/{org}/organization-roles', { org });
-              triageRole = roles.find(r =>
-                (r.name && r.name.toLowerCase() === 'all-repository triage') ||
-                (r.slug && r.slug.toLowerCase() === 'all-repository-triage') ||
-                /all.*triage/i.test(r.name || '')
-              );
-              if (!triageRole) throw new Error('Org role not found: All-repository triage');
-              core.info(`Found role: ${triageRole.name} (id=${triageRole.id})`);
+              core.info('Roles: ' + roles.map(r => `${r.id}:${r.name}`).join(' | '));
             } catch (e) {
-              core.setFailed(`Unable to list/find org roles: ${e.message}`);
-              return;
+              core.setFailed(`Listing roles failed: ${e.message}`);
             }
-
-            // 2) Get all members (role=member)
-            const members = await github.paginate(github.rest.orgs.listMembers, {
-              org,
-              per_page: 100,
-              role: 'member'
-            });
-
-            // Optional: also include owners
-            const includeOwners = false;
-            let owners = [];
-            if (includeOwners) {
-              owners = await github.paginate(github.rest.orgs.listMembers, {
-                org,
-                per_page: 100,
-                role: 'admin'
-              });
-            }
-
-            const targets = [...members, ...owners]
-              .map(u => u.login.toLowerCase())
-              .filter(u => !EXCLUDE.has(u));
-
-            if (targets.length === 0) {
-              core.info('No eligible members to process.');
-              return;
-            }
-
-            let table = '\n| User | Action |\n|---|---|\n';
-
-            for (const username of targets) {
-              try {
-                // 3) Get current role assignments
-                let currentRoles = [];
-                try {
-                  const { data } = await github.request(
-                    'GET /orgs/{org}/organization-roles/users/{username}',
-                    { org, username }
-                  );
-                  currentRoles = Array.isArray(data) ? data : (data.roles || data || []);
-                } catch (e) {
-                  if (e.status !== 404) {
-                    table += `| ${username} | ⚠️ read roles failed: ${e.message} |\n`;
-                    continue;
-                  }
-                }
-
-                const currentIds = new Set(
-                  currentRoles.map(r => r.id || r.role_id).filter(Boolean)
-                );
-
-                if (currentIds.has(triageRole.id)) {
-                  table += `| ${username} | ➖ already has All-repo triage |\n`;
-                  continue;
-                }
-
-                currentIds.add(triageRole.id);
-                const role_ids = Array.from(currentIds);
-
-                if (dryRun) {
-                  table += `| ${username} | 🛑 dry-run: would assign All-repo triage |\n`;
-                  continue;
-                }
-
-                await github.request(
-                  'PUT /orgs/{org}/organization-roles/users/{username}',
-                  { org, username, role_ids }
-                );
-
-                table += `| ${username} | ✅ assigned All-repo triage |\n`;
-              } catch (e) {
-                table += `| ${username} | ❌ assignment failed: ${e.message} |\n`;
-              }
-            }
-
-            await core.summary
-              .addHeading('All-repository triage enforcement')
-              .addRaw(table, true)
-              .write();

--- a/.github/workflows/triage-contributors.yml
+++ b/.github/workflows/triage-contributors.yml
@@ -9,20 +9,15 @@ jobs:
           github-token: ${{ secrets.ORG_INVITE }}
           script: |
             const org = 'armbian';
-            // Show who we are
             const me = await github.request('GET /user');
             core.info(`Token user: ${me.data.login}`);
-            // Confirm ownership level (owner vs member)
-            try {
-              const m = await github.request('GET /user/memberships/orgs/{org}', { org });
-              core.info(`Org role: ${m.data.role}`); // should be 'admin' for owners
-            } catch (e) {
-              core.warning(`Membership check failed: ${e.message}`);
+
+            const { data } = await github.request('GET /orgs/{org}/organization-roles', { org });
+            if (!data.roles) {
+              core.info('No roles array in response: ' + JSON.stringify(data, null, 2));
+              return;
             }
-            // List roles
-            try {
-              const { data: roles } = await github.request('GET /orgs/{org}/organization-roles', { org });
-              core.info('Roles: ' + roles.map(r => `${r.id}:${r.name}`).join(' | '));
-            } catch (e) {
-              core.setFailed(`Listing roles failed: ${e.message}`);
+
+            for (const r of data.roles) {
+              core.info(`${r.id}: ${r.name}`);
             }

--- a/.github/workflows/triage-contributors.yml
+++ b/.github/workflows/triage-contributors.yml
@@ -2,10 +2,10 @@ name: Ensure All Members Have All-Repo Triage
 
 on:
   schedule:
-    - cron: '0 3 * * 1'   # Weekly, 03:00 UTC on Mondays
+    - cron: '0 3 * * 1'   # Weekly
   workflow_dispatch:
     inputs:
-      dry-run:
+      dry_run:
         description: 'Simulate without changing roles'
         required: false
         default: 'false'
@@ -21,14 +21,14 @@ jobs:
       - name: Ensure triage role for all members
         uses: actions/github-script@v7
         with:
-          # Fine-grained token with org admin perms:
-          # Organization administration (Read & write)
           github-token: ${{ secrets.ORG_INVITE }}
           script: |
             const org = 'armbian';
-            const dryRun = '${{ github.event.inputs["dry-run"] }}' === 'true';
-            const excludeCsv = '${{ github.event.inputs["exclude"] }}'.trim();
-            const EXCLUDE = new Set(excludeCsv ? excludeCsv.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : []);
+            const dryRun = '${{ github.event.inputs.dry_run }}' === 'true';
+            const excludeCsv = '${{ github.event.inputs.exclude }}'.trim();
+            const EXCLUDE = new Set(
+              excludeCsv ? excludeCsv.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : []
+            );
 
             // 1) Find the "All-repository triage" role
             let triageRole = null;
@@ -46,14 +46,14 @@ jobs:
               return;
             }
 
-            // 2) Get all members (role=member). Owners are handled separately.
+            // 2) Get all members (role=member)
             const members = await github.paginate(github.rest.orgs.listMembers, {
               org,
               per_page: 100,
               role: 'member'
             });
 
-            // Optional: also include owners if you want (set includeOwners=true)
+            // Optional: also include owners
             const includeOwners = false;
             let owners = [];
             if (includeOwners) {
@@ -64,7 +64,6 @@ jobs:
               });
             }
 
-            // Build final target list
             const targets = [...members, ...owners]
               .map(u => u.login.toLowerCase())
               .filter(u => !EXCLUDE.has(u));
@@ -78,15 +77,15 @@ jobs:
 
             for (const username of targets) {
               try {
-                // 3) Get current role assignments for the user so we don't overwrite them
+                // 3) Get current role assignments
                 let currentRoles = [];
                 try {
-                  const { data } = await github.request('GET /orgs/{org}/organization-roles/users/{username}', {
-                    org, username
-                  });
+                  const { data } = await github.request(
+                    'GET /orgs/{org}/organization-roles/users/{username}',
+                    { org, username }
+                  );
                   currentRoles = Array.isArray(data) ? data : (data.roles || data || []);
                 } catch (e) {
-                  // Some orgs return 404 if no roles yet; that's okay.
                   if (e.status !== 404) {
                     table += `| ${username} | ⚠️ read roles failed: ${e.message} |\n`;
                     continue;
@@ -94,18 +93,14 @@ jobs:
                 }
 
                 const currentIds = new Set(
-                  currentRoles
-                    .map(r => r.id || r.role_id) // accept either shape
-                    .filter(Boolean)
+                  currentRoles.map(r => r.id || r.role_id).filter(Boolean)
                 );
 
-                const alreadyHas = currentIds.has(triageRole.id);
-                if (alreadyHas) {
+                if (currentIds.has(triageRole.id)) {
                   table += `| ${username} | ➖ already has All-repo triage |\n`;
                   continue;
                 }
 
-                // Merge: keep existing roles + add triage
                 currentIds.add(triageRole.id);
                 const role_ids = Array.from(currentIds);
 
@@ -114,12 +109,12 @@ jobs:
                   continue;
                 }
 
-                // 4) Update assignment (merge set)
-                await github.request('PUT /orgs/{org}/organization-roles/users/{username}', {
-                  org, username, role_ids
-                });
+                await github.request(
+                  'PUT /orgs/{org}/organization-roles/users/{username}',
+                  { org, username, role_ids }
+                );
 
-                table += `| ${username} | ✅ assigned All-repo triage (merged) |\n`;
+                table += `| ${username} | ✅ assigned All-repo triage |\n`;
               } catch (e) {
                 table += `| ${username} | ❌ assignment failed: ${e.message} |\n`;
               }

--- a/.github/workflows/triage-contributors.yml
+++ b/.github/workflows/triage-contributors.yml
@@ -1,23 +1,125 @@
-name: Probe Org Roles
-on: workflow_dispatch
+name: Ensure All Members Have All-Repo Triage
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'   # Weekly, Monday 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Simulate without changing roles'
+        required: false
+        default: 'false'
+      exclude:
+        description: 'Comma-separated usernames to exclude'
+        required: false
+        default: ''
+
 jobs:
-  probe:
+  enforce-triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - name: Ensure all members have All-repo triage
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.ORG_INVITE }}
           script: |
             const org = 'armbian';
-            const me = await github.request('GET /user');
-            core.info(`Token user: ${me.data.login}`);
+            const dryRun = '${{ github.event.inputs.dry_run }}' === 'true';
+            const excludeCsv = '${{ github.event.inputs.exclude }}'.trim();
+            const EXCLUDE = new Set(
+              excludeCsv ? excludeCsv.split(',').map(s => s.trim().toLowerCase()) : []
+            );
 
-            const { data } = await github.request('GET /orgs/{org}/organization-roles', { org });
-            if (!data.roles) {
-              core.info('No roles array in response: ' + JSON.stringify(data, null, 2));
+            // 1) Find the "All-repository triage" role
+            let triageRole = null;
+            try {
+              const { data } = await github.request('GET /orgs/{org}/organization-roles', { org });
+              triageRole = data.roles.find(r =>
+                (r.name && r.name.toLowerCase() === 'all-repository triage') ||
+                (r.slug && r.slug.toLowerCase() === 'all-repository-triage') ||
+                /all.*triage/i.test(r.name || '')
+              );
+              if (!triageRole) throw new Error('Org role not found: All-repository triage');
+              core.info(`Found role: ${triageRole.name} (id=${triageRole.id})`);
+            } catch (e) {
+              core.setFailed(`Unable to list/find org roles: ${e.message}`);
               return;
             }
 
-            for (const r of data.roles) {
-              core.info(`${r.id}: ${r.name}`);
+            // 2) Get all regular members (exclude owners by default)
+            const members = await github.paginate(github.rest.orgs.listMembers, {
+              org,
+              per_page: 100,
+              role: 'member'
+            });
+
+            const includeOwners = false; // set true if you want owners too
+            let owners = [];
+            if (includeOwners) {
+              owners = await github.paginate(github.rest.orgs.listMembers, {
+                org,
+                per_page: 100,
+                role: 'admin'
+              });
             }
+
+            const targets = [...members, ...owners]
+              .map(u => u.login.toLowerCase())
+              .filter(u => !EXCLUDE.has(u));
+
+            if (!targets.length) {
+              core.info('No eligible members to process.');
+              return;
+            }
+
+            let table = '\n| User | Action |\n|---|---|\n';
+
+            for (const username of targets) {
+              try {
+                // 3) Get current role assignments
+                let currentRoles = [];
+                try {
+                  const { data } = await github.request(
+                    'GET /orgs/{org}/organization-roles/users/{username}',
+                    { org, username }
+                  );
+                  currentRoles = Array.isArray(data) ? data : (data.roles || []);
+                } catch (e) {
+                  if (e.status !== 404) {
+                    table += `| ${username} | ⚠️ read roles failed: ${e.message} |\n`;
+                    continue;
+                  }
+                }
+
+                const currentIds = new Set(
+                  currentRoles.map(r => r.id || r.role_id).filter(Boolean)
+                );
+
+                if (currentIds.has(triageRole.id)) {
+                  table += `| ${username} | ➖ already has All-repo triage |\n`;
+                  continue;
+                }
+
+                currentIds.add(triageRole.id);
+                const role_ids = Array.from(currentIds);
+
+                if (dryRun) {
+                  table += `| ${username} | 🛑 dry-run: would assign All-repo triage |\n`;
+                  continue;
+                }
+
+                await github.request(
+                  'PUT /orgs/{org}/organization-roles/users/{username}',
+                  { org, username, role_ids }
+                );
+
+                table += `| ${username} | ✅ assigned All-repo triage |\n`;
+              } catch (e) {
+                table += `| ${username} | ❌ assignment failed: ${e.message} |\n`;
+              }
+            }
+
+            await core.summary
+              .addHeading('All-repository triage enforcement')
+              .addRaw(table, true)
+              .write();


### PR DESCRIPTION
## Summary

This PR introduces a scheduled GitHub Actions workflow that ensures all existing organization members are granted the **All-repository triage** role. This complements our contributor onboarding process by standardizing permissions across the org.

## Details

- **New workflow:** `.github/workflows/triage-contributors.yml`  
- **Schedule:** Runs weekly (Monday, 03:00 UTC), and can also be triggered manually.  
- **Logic:**
  - Lists all org members (excluding owners by default, configurable).  
  - Skips any members already holding the **All-repository triage** role.  
  - Assigns the role to everyone else.  
  - Provides a summary table in the job output.  
  - Supports `dry_run` mode and an `exclude` list for exceptions.  
- **Idempotent:** Safe to re-run any number of times. Only adds the role if missing.  
- **Permissions:** Requires `ORG_INVITE` secret containing a fine-grained PAT (org Owner) with **Custom organization roles → Read & write** (or classic PAT with `admin:org`).  

## Why

- https://github.com/armbian/build/issues/8579
- Ensures contributors consistently have the lowest-risk, useful org-wide permission (`triage`).  
- Reduces manual role management effort.  
- Lets contributors help with issue/PR housekeeping without giving them code merge rights.  
- Aligns with our goal to streamline support and triage duties across Armbian projects.  

## Notes

- Owners are excluded by default; can be included by toggling `includeOwners = true` in the script.  
- Pending invitees will be handled once they join, since the workflow runs weekly.  
- Complements the existing “Invite Recent Contributors” workflow.  

<img width="608" height="299" alt="image" src="https://github.com/user-attachments/assets/c26c6a06-8137-412e-864f-fb9e4a70d95d" />