### PR TITLE
Update PR filtering logic in release logs workflow

### DIFF
--- a/.github/workflows/generate-release-logs.yml
+++ b/.github/workflows/generate-release-logs.yml
@@ -123,12 +123,20 @@ jobs:
             title=$(jq -r .title <<<"$pr")
             author=$(jq -r .user.login <<<"$pr")
             pr_url=$(jq -r .html_url <<<"$pr")
-
-            # Skip bots and worker accounts
-            if [[ "$author" == "github-actions[bot]" || "$author" == "dependabot[bot]" || "$author" == "armbianworker" || "$author" == "armbianworker[bot]" ]]; then
-              continue
+            
+            # Skip bots, workers, and bump/revert PRs
+            title_lc="$(echo "$title" | tr '[:upper:]' '[:lower:]')"
+            if [[ "$author" == "github-actions[bot]" || \
+                  "$author" == "dependabot[bot]" || \
+                  "$author" == "armbianworker" || \
+                  "$author" == "armbianworker[bot]" || \
+                  "$title_lc" == bump* || \
+                  "$title_lc" == revert* || \
+                  "$title_lc" =~ "bump "* || \
+                  "$title_lc" =~ "revert "* ]]; then
+                  continue
             fi
-
+            
             # Output tab-separated: title, author, repo, pr_number, pr_url
             printf "%s\t%s\t%s\t%s\t%s\n" "$title" "$author" "$repo" "$num" "$pr_url"
           done | LC_ALL=C sort -f -t $'\t' -k1,1 > "$outfile"


### PR DESCRIPTION
Enhanced the script to skip bump and revert pull requests in addition to bots and worker accounts.