### PR TITLE
Remove radxa-dragon-q6a from targets-release-nightly blacklist

### DIFF
--- a/release-targets/targets-release-nightly.blacklist
+++ b/release-targets/targets-release-nightly.blacklist
@@ -22,5 +22,4 @@ xiaomi-elish
 uefi-x86
 mekotronics-r58-4x4
 mekotronics-r58hd
-radxa-dragon-q6a
 dg-svr-865-tiny


### PR DESCRIPTION
Removed 'radxa-dragon-q6a' from the blacklist.

@HeyMeco 