### PR TITLE
Harden data-update-partners workflow

### DIFF
--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -149,10 +149,13 @@ jobs:
                 avatar_url=""
               fi
 
-              # Get days since last activity in Armbian org (commits, issues, comments)
+              # Get days since last activity in Armbian org (commits, issues)
               echo "Fetching days since last activity for $username..."
-              days_since=$(python3 armbian.github.io/scripts/days_since_last_commit.py --days-only armbian "$username" "$GH_TOKEN")
-              if [ "$days_since" = "-1" ]; then
+              days_since=$(python3 armbian.github.io/scripts/days_since_last_commit.py --days-only armbian "$username" "$GH_TOKEN" || true)
+              if [ "$days_since" = "ERROR" ] || [ -z "$days_since" ]; then
+                echo "::warning::Lookup failed for $username, skipping activity data"
+                days_since="-1"
+              elif [ "$days_since" = "-1" ]; then
                 echo "  -> $username: no activity found in org"
               else
                 echo "  -> $username: ${days_since} days since last activity"

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -125,9 +125,17 @@ jobs:
               # Extract GitHub username from the URL
               github_url=$(echo "$row" | jq -r '.Github')
               username=$(basename "$github_url")
+              first_name=$(echo "$row" | jq -r '.First_Name // empty')
+              last_name=$(echo "$row" | jq -r '.Last_Name // empty')
+
+              # Skip entries without a valid GitHub username
+              if [ -z "$username" ] || [ "$username" = "null" ] || [ "$username" = "." ]; then
+                echo "::warning::Skipping maintainer '${first_name} ${last_name}' - no GitHub profile set"
+                continue
+              fi
 
               # Fetch GitHub profile for avatar URL
-              echo "Processing maintainer: $username"
+              echo "Processing maintainer: $username (${first_name} ${last_name})"
               avatar_url=$(curl -s -H "Authorization: token $GH_TOKEN" "https://api.github.com/users/$username" | jq -r '.avatar_url')
 
               # Fall back to empty string if avatar fetch failed

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -116,10 +116,15 @@ jobs:
           # Flag for commas between records
           first=1
 
-          # Fetch the maintainers from Zoho Bigin
-          curl --silent --fail --request GET \
+          # Fetch the maintainers from Zoho Bigin (fail fast on error, same as partners fetch)
+          if ! maintainers_response=$(curl --silent --fail --request GET \
             --url 'https://www.zohoapis.eu/bigin/v2/Contacts/search?fields=Team,First_Name,Last_Name,Github,Maintaining,Your_core_competences&criteria=((Tag:equals:maintainer)and(Inactive:equals:false))' \
-            --header "Authorization: Zoho-oauthtoken $ACCESS_TOKEN" \
+            --header "Authorization: Zoho-oauthtoken $ACCESS_TOKEN"); then
+            echo "::error::Failed to fetch maintainers from Zoho"
+            exit 1
+          fi
+
+          echo "$maintainers_response" \
           | jq -c '.data[] | {First_Name, Last_Name, Github, Team, Maintaining, Your_core_competences}' \
           | while read -r row; do
               # Extract GitHub username from the URL

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -144,19 +144,18 @@ jobs:
                 avatar_url=""
               fi
 
-              # Get days since last commit to Armbian org (with delay to avoid search API rate limits)
-              sleep 2
-              echo "Fetching days since last commit for $username..."
+              # Get days since last activity in Armbian org (commits, issues, comments)
+              echo "Fetching days since last activity for $username..."
               days_since=$(python3 armbian.github.io/scripts/days_since_last_commit.py --days-only armbian "$username" "$GH_TOKEN")
               if [ "$days_since" = "-1" ]; then
-                echo "  -> $username: no commits found in org"
+                echo "  -> $username: no activity found in org"
               else
-                echo "  -> $username: ${days_since} days since last commit"
+                echo "  -> $username: ${days_since} days since last activity"
               fi
 
-              # Enrich Zoho data with GitHub avatar, days since last commit, and Last_Name fallback
+              # Enrich Zoho data with GitHub avatar, days since last activity, and Last_Name fallback
               enriched=$(echo "$row" | jq --arg avatar "$avatar_url" --arg days "$days_since" '
-                . + {Avatar: $avatar, Days_since_last_commit: ($days | tonumber)}
+                . + {Avatar: $avatar, Days_since_last_activity: ($days | tonumber)}
                 | if (.First_Name == null or .First_Name == "") and (.Last_Name != null and .Last_Name != "")
                   then .First_Name = .Last_Name
                   else . end

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -141,7 +141,7 @@ jobs:
 
               # Fetch GitHub profile for avatar URL
               echo "Processing maintainer: $username (${first_name} ${last_name})"
-              avatar_url=$(curl -s -H "Authorization: token $GH_TOKEN" "https://api.github.com/users/$username" | jq -r '.avatar_url')
+              avatar_url=$(curl -s -H "Authorization: token $GH_TOKEN" "https://api.github.com/users/$username" | jq -r '.avatar_url' || true)
 
               # Fall back to empty string if avatar fetch failed
               if [ "$avatar_url" = "null" ] || [ -z "$avatar_url" ]; then

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -127,6 +127,7 @@ jobs:
               username=$(basename "$github_url")
 
               # Fetch GitHub profile for avatar URL
+              echo "Processing maintainer: $username"
               avatar_url=$(curl -s -H "Authorization: token $GH_TOKEN" "https://api.github.com/users/$username" | jq -r '.avatar_url')
 
               # Fall back to empty string if avatar fetch failed
@@ -136,7 +137,9 @@ jobs:
               fi
 
               # Get days since last commit to Armbian org
+              echo "Fetching days since last commit for $username..."
               days_since=$(python3 armbian.github.io/scripts/days_since_last_commit.py --days-only armbian "$username" "$GH_TOKEN")
+              echo "  -> $username: ${days_since} days"
 
               # Enrich Zoho data with GitHub avatar, days since last commit, and Last_Name fallback
               enriched=$(echo "$row" | jq --arg avatar "$avatar_url" --arg days "$days_since" '

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -54,11 +54,9 @@ jobs:
           > partners.json
 
           for partner_type in Platinum Gold Silver; do
-            response=$(curl --silent --fail --request GET \
+            if ! response=$(curl --silent --fail --request GET \
               --url "https://www.zohoapis.eu/bigin/v2/Accounts/search?fields=Website,Company_slug,Description,Account_Name,Email,Partnership_Status,Promoted&criteria=((Partnership_Status:equals:${partner_type}%20Partner)and(Promoted:equals:true))" \
-              --header "Authorization: Zoho-oauthtoken $ACCESS_TOKEN")
-
-            if [ $? -ne 0 ]; then
+              --header "Authorization: Zoho-oauthtoken $ACCESS_TOKEN"); then
               echo "::warning::Failed to fetch ${partner_type} partners"
               continue
             fi

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -104,6 +104,9 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           done
 
+          # Install Python dependencies for days_since_last_commit script
+          pip install --quiet requests
+
           # Create a temporary file for maintainers_with_avatars.json
           temp_file=$(mktemp)
 
@@ -132,9 +135,12 @@ jobs:
                 avatar_url=""
               fi
 
-              # Enrich Zoho data with GitHub avatar, use Last_Name as First_Name if First_Name is empty
-              enriched=$(echo "$row" | jq --arg avatar "$avatar_url" '
-                . + {Avatar: $avatar}
+              # Get days since last commit to Armbian org
+              days_since=$(python3 armbian.github.io/scripts/days_since_last_commit.py --days-only armbian "$username" "$GH_TOKEN")
+
+              # Enrich Zoho data with GitHub avatar, days since last commit, and Last_Name fallback
+              enriched=$(echo "$row" | jq --arg avatar "$avatar_url" --arg days "$days_since" '
+                . + {Avatar: $avatar, Days_since_last_commit: ($days | tonumber)}
                 | if (.First_Name == null or .First_Name == "") and (.Last_Name != null and .Last_Name != "")
                   then .First_Name = .Last_Name
                   else . end

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -147,7 +147,11 @@ jobs:
               # Get days since last commit to Armbian org
               echo "Fetching days since last commit for $username..."
               days_since=$(python3 armbian.github.io/scripts/days_since_last_commit.py --days-only armbian "$username" "$GH_TOKEN")
-              echo "  -> $username: ${days_since} days"
+              if [ "$days_since" = "-1" ]; then
+                echo "  -> $username: no commits found in org"
+              else
+                echo "  -> $username: ${days_since} days since last commit"
+              fi
 
               # Enrich Zoho data with GitHub avatar, days since last commit, and Last_Name fallback
               enriched=$(echo "$row" | jq --arg avatar "$avatar_url" --arg days "$days_since" '

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: armbian/armbian.github.io
-          fetch-depth: 0
+          fetch-depth: 1
           clean: false
           path: armbian.github.io
 
@@ -33,13 +33,20 @@ jobs:
           REFRESH_TOKEN: ${{ secrets.ZOHO_REFRESH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           ACCESS_TOKEN=$(curl -sH "Content-type: multipart/form-data" \
-            -F refresh_token=$REFRESH_TOKEN \
-            -F client_id=$CLIENT_ID \
-            -F client_secret=$CLIENT_SECRET \
+            -F "refresh_token=$REFRESH_TOKEN" \
+            -F "client_id=$CLIENT_ID" \
+            -F "client_secret=$CLIENT_SECRET" \
             -F grant_type=refresh_token \
             -X POST https://accounts.zoho.eu/oauth/v2/token \
             | jq -r '.access_token')
+
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "::error::Failed to obtain Zoho access token"
+            exit 1
+          fi
 
           echo "Access token obtained."
 
@@ -47,12 +54,19 @@ jobs:
           > partners.json
 
           for partner_type in Platinum Gold Silver; do
-            curl --silent --request GET \
+            response=$(curl --silent --fail --request GET \
               --url "https://www.zohoapis.eu/bigin/v2/Accounts/search?fields=Website,Company_slug,Description,Account_Name,Email,Partnership_Status,Promoted&criteria=((Partnership_Status:equals:${partner_type}%20Partner)and(Promoted:equals:true))" \
-              --header "Authorization: Zoho-oauthtoken $ACCESS_TOKEN" \
+              --header "Authorization: Zoho-oauthtoken $ACCESS_TOKEN")
+
+            if [ $? -ne 0 ]; then
+              echo "::warning::Failed to fetch ${partner_type} partners"
+              continue
+            fi
+
+            echo "$response" \
               | jq -c ".data[] | select(.Company_slug != null and .Company_slug != \"\") | {
                   Account_Name,
-                  logo_url: (\"https://cache.armbian.com/images/vendors/150/\(.Company_slug)-border.png\"),
+                  logo_url: (\"https://cache.armbian.com/images/vendors/150/\(.Company_slug).png\"),
                   Website,
                   Description,
                   Partnership_Status: .Partnership_Status
@@ -63,37 +77,34 @@ jobs:
           jq -s . < partners.json > partners.json.tmp && mv partners.json.tmp partners.json
           jq . -S < partners.json > partners.json.tmp && mv partners.json.tmp partners.json
 
+          # Validate partners data
+          partner_count=$(jq 'length' partners.json)
+          if [ "$partner_count" -lt 1 ]; then
+            echo "::error::Partners JSON is empty, refusing to commit"
+            exit 1
+          fi
+          echo "Fetched $partner_count partners."
+
           # Display content in step summary as markdown sections
           echo "# Partners" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Platinum Partners
-          echo "## Platinum" >> $GITHUB_STEP_SUMMARY
-          echo '<p align=left>' >> $GITHUB_STEP_SUMMARY
           TIMESTAMP=$(date +%s)
-          jq -r --arg ts "$TIMESTAMP" '.[] | select(.Partnership_Status == "Platinum Partner") |
-            "<a href='\''\(.Website)'\''><img src='\''\(.logo_url)?v=\($ts)'\'' width='\''150'\'' alt='\''\(.Account_Name)'\'' style=\"display:block; border:0; height:auto;\"></a>"' \
-            partners.json | tr '\n' ' ' >> $GITHUB_STEP_SUMMARY
-          echo '</p>' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Gold Partners
-          echo "## Gold" >> $GITHUB_STEP_SUMMARY
-          echo '<p align=left>' >> $GITHUB_STEP_SUMMARY
-          jq -r --arg ts "$TIMESTAMP" '.[] | select(.Partnership_Status == "Gold Partner") |
-            "<a href='\''\(.Website)'\''><img src='\''\(.logo_url)?v=\($ts)'\'' width='\''105'\'' alt='\''\(.Account_Name)'\'' style=\"display:block; border:0; height:auto;\"></a>"' \
-            partners.json | tr '\n' ' ' >> $GITHUB_STEP_SUMMARY
-          echo '</p>' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Silver Partners
-          echo "## Silver" >> $GITHUB_STEP_SUMMARY
-          echo '<p align=left>' >> $GITHUB_STEP_SUMMARY
-          jq -r --arg ts "$TIMESTAMP" '.[] | select(.Partnership_Status == "Silver Partner") |
-            "<a href='\''\(.Website)'\''><img src='\''\(.logo_url)?v=\($ts)'\'' width='\''75'\'' alt='\''\(.Account_Name)'\'' style=\"display:block; border:0; height:auto;\"></a>"' \
-            partners.json | tr '\n' ' ' >> $GITHUB_STEP_SUMMARY
-          echo '</p>' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          for level in Platinum Gold Silver; do
+            case $level in
+              Platinum) width=150 ;;
+              Gold)     width=105 ;;
+              Silver)   width=75 ;;
+            esac
+            echo "## ${level}" >> $GITHUB_STEP_SUMMARY
+            echo '<p align=left>' >> $GITHUB_STEP_SUMMARY
+            jq -r --arg ts "$TIMESTAMP" --arg status "${level} Partner" --arg w "$width" \
+              '.[] | select(.Partnership_Status == $status) |
+              "<a href='\''\(.Website)'\''><img src='\''\(.logo_url)?v=\($ts)'\'' width='\''\($w)'\'' alt='\''\(.Account_Name)'\'' style=\"display:block; border:0; height:auto;\"></a>"' \
+              partners.json | tr '\n' ' ' >> $GITHUB_STEP_SUMMARY
+            echo '</p>' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          done
 
           # Create a temporary file for maintainers_with_avatars.json
           temp_file=$(mktemp)
@@ -105,23 +116,32 @@ jobs:
           first=1
 
           # Fetch the maintainers from Zoho Bigin
-          curl --silent --request GET \
-            --url 'https://www.zohoapis.eu/bigin/v2/Contacts/search?fields=Team,First_Name,Github,Maintaining,Your_core_competences&criteria=((Tag:equals:maintainer)and(Inactive:equals:false))' \
+          curl --silent --fail --request GET \
+            --url 'https://www.zohoapis.eu/bigin/v2/Contacts/search?fields=Team,First_Name,Last_Name,Github,Maintaining,Your_core_competences&criteria=((Tag:equals:maintainer)and(Inactive:equals:false))' \
             --header "Authorization: Zoho-oauthtoken $ACCESS_TOKEN" \
-          | jq -c '.data[] | {First_Name, Github, Team, Maintaining, Your_core_competences}' \
+          | jq -c '.data[] | {First_Name, Last_Name, Github, Team, Maintaining, Your_core_competences}' \
           | while read -r row; do
               # Extract GitHub username from the URL
               github_url=$(echo "$row" | jq -r '.Github')
               username=$(basename "$github_url")
 
-              # Assume GH_TOKEN is exported as env var or injected from GitHub Actions secrets
-              auth_header="Authorization: token $GH_TOKEN"
-
               # Fetch GitHub profile for avatar URL
-              avatar_url=$(curl -s -H "$auth_header" "https://api.github.com/users/$username" | jq -r '.avatar_url')
+              avatar_url=$(curl -s -H "Authorization: token $GH_TOKEN" "https://api.github.com/users/$username" | jq -r '.avatar_url')
 
-              # Enrich Zoho data with GitHub avatar
-              enriched=$(echo "$row" | jq --arg avatar "$avatar_url" '. + {Avatar: $avatar}')
+              # Fall back to empty string if avatar fetch failed
+              if [ "$avatar_url" = "null" ] || [ -z "$avatar_url" ]; then
+                echo "::warning::Could not fetch avatar for $username"
+                avatar_url=""
+              fi
+
+              # Enrich Zoho data with GitHub avatar, use Last_Name as First_Name if First_Name is empty
+              enriched=$(echo "$row" | jq --arg avatar "$avatar_url" '
+                . + {Avatar: $avatar}
+                | if (.First_Name == null or .First_Name == "") and (.Last_Name != null and .Last_Name != "")
+                  then .First_Name = .Last_Name
+                  else . end
+                | del(.Last_Name)
+              ')
 
               # Manage commas between JSON objects
               if [ $first -eq 1 ]; then
@@ -137,8 +157,16 @@ jobs:
           # Close the JSON array
           echo "]" >> "$temp_file"
 
-          # Format and save the final output to fixed.json
-          cat "$temp_file" | jq . > maintainers.json
+          # Format and save the final output
+          jq . "$temp_file" > maintainers.json
+
+          # Validate maintainers data
+          maintainer_count=$(jq 'length' maintainers.json)
+          if [ "$maintainer_count" -lt 1 ]; then
+            echo "::error::Maintainers JSON is empty, refusing to commit"
+            exit 1
+          fi
+          echo "Fetched $maintainer_count maintainers."
 
           # Clean up the temporary file
           rm "$temp_file"

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -144,7 +144,8 @@ jobs:
                 avatar_url=""
               fi
 
-              # Get days since last commit to Armbian org
+              # Get days since last commit to Armbian org (with delay to avoid search API rate limits)
+              sleep 2
               echo "Fetching days since last commit for $username..."
               days_since=$(python3 armbian.github.io/scripts/days_since_last_commit.py --days-only armbian "$username" "$GH_TOKEN")
               if [ "$days_since" = "-1" ]; then

--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -57,8 +57,8 @@ jobs:
             if ! response=$(curl --silent --fail --request GET \
               --url "https://www.zohoapis.eu/bigin/v2/Accounts/search?fields=Website,Company_slug,Description,Account_Name,Email,Partnership_Status,Promoted&criteria=((Partnership_Status:equals:${partner_type}%20Partner)and(Promoted:equals:true))" \
               --header "Authorization: Zoho-oauthtoken $ACCESS_TOKEN"); then
-              echo "::warning::Failed to fetch ${partner_type} partners"
-              continue
+              echo "::error::Failed to fetch ${partner_type} partners"
+              exit 1
             fi
 
             echo "$response" \

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -1,94 +1,32 @@
 #!/usr/bin/env python3
 import sys
-import time
 import requests
 from datetime import datetime, timezone
 
 API = "https://api.github.com"
 
 
-def gh_get(url, token, params=None):
+def days_since_last_commit(org, user, token):
     headers = {
-        "Accept": "application/vnd.github+json",
+        "Accept": "application/vnd.github.cloak-preview+json",
         "Authorization": f"Bearer {token}",
         "User-Agent": "org-last-commit-check",
     }
-    r = requests.get(url, headers=headers, params=params, timeout=30)
-    r.raise_for_status()
-    return r.json()
-
-
-def get_pinned_repos(org, token):
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-    query = """
-    query($org: String!) {
-      organization(login: $org) {
-        pinnedItems(first: 6, types: REPOSITORY) {
-          nodes {
-            ... on Repository {
-              name
-            }
-          }
-        }
-      }
-    }
-    """
-    r = requests.post(
-        "https://api.github.com/graphql",
+    r = requests.get(
+        f"{API}/search/commits",
         headers=headers,
-        json={"query": query, "variables": {"org": org}},
+        params={"q": f"author:{user} org:{org}", "sort": "author-date", "order": "desc", "per_page": 1},
         timeout=30,
     )
     r.raise_for_status()
     data = r.json()
-    nodes = data["data"]["organization"]["pinnedItems"]["nodes"]
-    return [{"name": n["name"]} for n in nodes]
 
+    if data.get("total_count", 0) == 0:
+        return None
 
-def get_latest_commit_date(org, repo, user, token, retries=3):
-    for attempt in range(retries):
-        try:
-            commits = gh_get(
-                f"{API}/repos/{org}/{repo}/commits",
-                token,
-                params={"author": user, "per_page": 1},
-            )
-            if not commits:
-                return None
-            return commits[0]["commit"]["author"]["date"]
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code >= 500 and attempt < retries - 1:
-                time.sleep(2 ** attempt)
-                continue
-            return None
-
-
-def days_since_last_commit(org, user, token):
-    repos = get_pinned_repos(org, token)
-
-    latest_date = None
-    latest_repo = None
-
-    for repo in repos:
-        name = repo["name"]
-        try:
-            date_str = get_latest_commit_date(org, name, user, token)
-            if date_str:
-                dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
-                if not latest_date or dt > latest_date:
-                    latest_date = dt
-                    latest_repo = name
-        except Exception as e:
-            print(f"[WARN] {name}: {e}", file=sys.stderr)
-
-    if not latest_date:
-        return None, None
-
-    now = datetime.now(timezone.utc)
-    return (now - latest_date).days, latest_repo
+    date_str = data["items"][0]["commit"]["author"]["date"]
+    dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    return (datetime.now(timezone.utc) - dt).days
 
 
 def main():
@@ -100,7 +38,7 @@ def main():
         sys.exit(1)
 
     org, user, token = args[0], args[1], args[2]
-    delta_days, latest_repo = days_since_last_commit(org, user, token)
+    delta_days = days_since_last_commit(org, user, token)
 
     if delta_days is None:
         if days_only:
@@ -112,7 +50,6 @@ def main():
     if days_only:
         print(delta_days)
     else:
-        print(f"Repository: {org}/{latest_repo}")
         print(f"Days since last commit: {delta_days}")
 
 

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import sys
+import requests
+from datetime import datetime, timezone
+
+API = "https://api.github.com"
+
+
+def gh_get(url, token, params=None):
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "User-Agent": "org-last-commit-check",
+    }
+    r = requests.get(url, headers=headers, params=params, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def get_all_repos(org, token):
+    repos = []
+    page = 1
+    while True:
+        batch = gh_get(
+            f"{API}/orgs/{org}/repos",
+            token,
+            params={"per_page": 100, "page": page, "type": "all"},
+        )
+        if not batch:
+            break
+        repos.extend(batch)
+        page += 1
+    return repos
+
+
+def get_latest_commit_date(org, repo, user, token):
+    commits = gh_get(
+        f"{API}/repos/{org}/{repo}/commits",
+        token,
+        params={"author": user, "per_page": 1},
+    )
+    if not commits:
+        return None
+
+    # commit.author.date is ISO8601
+    return commits[0]["commit"]["author"]["date"]
+
+
+def days_since_last_commit(org, user, token):
+    repos = get_all_repos(org, token)
+
+    latest_date = None
+    latest_repo = None
+
+    for repo in repos:
+        name = repo["name"]
+        try:
+            date_str = get_latest_commit_date(org, name, user, token)
+            if date_str:
+                dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                if not latest_date or dt > latest_date:
+                    latest_date = dt
+                    latest_repo = name
+        except Exception as e:
+            print(f"[WARN] {name}: {e}", file=sys.stderr)
+
+    if not latest_date:
+        return None, None
+
+    now = datetime.now(timezone.utc)
+    return (now - latest_date).days, latest_repo
+
+
+def main():
+    days_only = "--days-only" in sys.argv
+    args = [a for a in sys.argv[1:] if a != "--days-only"]
+
+    if len(args) != 3:
+        print("Usage: script.py [--days-only] ORG USER TOKEN")
+        sys.exit(1)
+
+    org, user, token = args[0], args[1], args[2]
+    delta_days, latest_repo = days_since_last_commit(org, user, token)
+
+    if delta_days is None:
+        if days_only:
+            print(-1)
+        else:
+            print(f"No commits found for {user} in org {org}")
+        sys.exit(0)
+
+    if days_only:
+        print(delta_days)
+    else:
+        print(f"Repository: {org}/{latest_repo}")
+        print(f"Days since last commit: {delta_days}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -7,9 +7,16 @@ from datetime import datetime, timezone
 API = "https://api.github.com"
 
 
+class LookupError(Exception):
+    pass
+
+
 def search_with_retry(url, headers, params, retries=5):
     for attempt in range(retries):
-        r = requests.get(url, headers=headers, params=params, timeout=30)
+        try:
+            r = requests.get(url, headers=headers, params=params, timeout=30)
+        except requests.exceptions.RequestException as e:
+            raise LookupError(f"Request failed: {e}")
 
         if r.status_code == 403:
             retry_after = int(r.headers.get("Retry-After", 10 * (2 ** attempt)))
@@ -20,10 +27,12 @@ def search_with_retry(url, headers, params, retries=5):
         if r.status_code == 422:
             return None
 
-        r.raise_for_status()
+        if not r.ok:
+            raise LookupError(f"HTTP {r.status_code}")
+
         return r.json()
 
-    return None
+    raise LookupError("Rate limit retries exhausted")
 
 
 def get_latest_commit_date(org, user, headers):
@@ -57,7 +66,7 @@ def days_since_last_activity(org, user, token):
 
     dates = []
     for fetch in (get_latest_commit_date, get_latest_issue_date):
-        dt = fetch(org, user, headers)
+        dt = fetch(org, user, headers)  # raises LookupError on failure
         if dt:
             dates.append(dt)
         time.sleep(1)
@@ -78,7 +87,15 @@ def main():
         sys.exit(1)
 
     org, user, token = args[0], args[1], args[2]
-    delta_days = days_since_last_activity(org, user, token)
+
+    try:
+        delta_days = days_since_last_activity(org, user, token)
+    except LookupError as e:
+        if days_only:
+            print("ERROR")
+        else:
+            print(f"Lookup failed for {user}: {e}")
+        sys.exit(1)
 
     if delta_days is None:
         if days_only:

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import time
 import requests
 from datetime import datetime, timezone
 
@@ -8,25 +9,42 @@ API = "https://api.github.com"
 
 def days_since_last_commit(org, user, token):
     headers = {
-        "Accept": "application/vnd.github.cloak-preview+json",
+        "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {token}",
         "User-Agent": "org-last-commit-check",
     }
-    r = requests.get(
-        f"{API}/search/commits",
-        headers=headers,
-        params={"q": f"author:{user} org:{org}", "sort": "author-date", "order": "desc", "per_page": 1},
-        timeout=30,
-    )
-    r.raise_for_status()
-    data = r.json()
 
-    if data.get("total_count", 0) == 0:
-        return None
+    for attempt in range(3):
+        r = requests.get(
+            f"{API}/search/commits",
+            headers=headers,
+            params={"q": f"author:{user} org:{org}", "sort": "author-date", "order": "desc", "per_page": 1},
+            timeout=30,
+        )
 
-    date_str = data["items"][0]["commit"]["author"]["date"]
-    dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
-    return (datetime.now(timezone.utc) - dt).days
+        if r.status_code == 403:
+            # Secondary rate limit - wait and retry
+            retry_after = int(r.headers.get("Retry-After", 2 ** (attempt + 1)))
+            print(f"Rate limited for {user}, retrying in {retry_after}s...", file=sys.stderr)
+            time.sleep(retry_after)
+            continue
+
+        if r.status_code == 422:
+            # Validation error (e.g. user not found)
+            return None
+
+        r.raise_for_status()
+        data = r.json()
+
+        if data.get("total_count", 0) == 0:
+            return None
+
+        date_str = data["items"][0]["commit"]["author"]["date"]
+        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        return (datetime.now(timezone.utc) - dt).days
+
+    # All retries exhausted
+    return None
 
 
 def main():

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -7,44 +7,77 @@ from datetime import datetime, timezone
 API = "https://api.github.com"
 
 
-def days_since_last_commit(org, user, token):
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "Authorization": f"Bearer {token}",
-        "User-Agent": "org-last-commit-check",
-    }
-
-    for attempt in range(5):
-        r = requests.get(
-            f"{API}/search/commits",
-            headers=headers,
-            params={"q": f"author:{user} org:{org}", "sort": "author-date", "order": "desc", "per_page": 1},
-            timeout=30,
-        )
+def search_with_retry(url, headers, params, retries=5):
+    for attempt in range(retries):
+        r = requests.get(url, headers=headers, params=params, timeout=30)
 
         if r.status_code == 403:
-            # Secondary rate limit - use Retry-After or exponential backoff (10s, 20s, 40s, 80s, 160s)
             retry_after = int(r.headers.get("Retry-After", 10 * (2 ** attempt)))
-            print(f"Rate limited for {user}, retrying in {retry_after}s (attempt {attempt + 1}/5)...", file=sys.stderr)
+            print(f"Rate limited, retrying in {retry_after}s (attempt {attempt + 1}/{retries})...", file=sys.stderr)
             time.sleep(retry_after)
             continue
 
         if r.status_code == 422:
-            # Validation error (e.g. user not found)
             return None
 
         r.raise_for_status()
-        data = r.json()
+        return r.json()
 
-        if data.get("total_count", 0) == 0:
-            return None
-
-        date_str = data["items"][0]["commit"]["author"]["date"]
-        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
-        return (datetime.now(timezone.utc) - dt).days
-
-    # All retries exhausted
     return None
+
+
+def get_latest_commit_date(org, user, headers):
+    data = search_with_retry(
+        f"{API}/search/commits", headers,
+        {"q": f"author:{user} org:{org}", "sort": "author-date", "order": "desc", "per_page": 1},
+    )
+    if not data or data.get("total_count", 0) == 0:
+        return None
+    date_str = data["items"][0]["commit"]["author"]["date"]
+    return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+
+
+def get_latest_issue_date(org, user, headers):
+    data = search_with_retry(
+        f"{API}/search/issues", headers,
+        {"q": f"author:{user} org:{org}", "sort": "created", "order": "desc", "per_page": 1},
+    )
+    if not data or data.get("total_count", 0) == 0:
+        return None
+    date_str = data["items"][0]["created_at"]
+    return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+
+
+def get_latest_comment_date(org, user, headers):
+    data = search_with_retry(
+        f"{API}/search/issues", headers,
+        {"q": f"commenter:{user} org:{org}", "sort": "updated", "order": "desc", "per_page": 1},
+    )
+    if not data or data.get("total_count", 0) == 0:
+        return None
+    date_str = data["items"][0]["updated_at"]
+    return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+
+
+def days_since_last_activity(org, user, token):
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "User-Agent": "org-activity-check",
+    }
+
+    dates = []
+    for fetch in (get_latest_commit_date, get_latest_issue_date, get_latest_comment_date):
+        dt = fetch(org, user, headers)
+        if dt:
+            dates.append(dt)
+        time.sleep(1)
+
+    if not dates:
+        return None
+
+    latest = max(dates)
+    return (datetime.now(timezone.utc) - latest).days
 
 
 def main():
@@ -56,19 +89,19 @@ def main():
         sys.exit(1)
 
     org, user, token = args[0], args[1], args[2]
-    delta_days = days_since_last_commit(org, user, token)
+    delta_days = days_since_last_activity(org, user, token)
 
     if delta_days is None:
         if days_only:
             print(-1)
         else:
-            print(f"No commits found for {user} in org {org}")
+            print(f"No activity found for {user} in org {org}")
         sys.exit(0)
 
     if days_only:
         print(delta_days)
     else:
-        print(f"Days since last commit: {delta_days}")
+        print(f"Days since last activity: {delta_days}")
 
 
 if __name__ == "__main__":

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -48,17 +48,6 @@ def get_latest_issue_date(org, user, headers):
     return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
 
 
-def get_latest_comment_date(org, user, headers):
-    data = search_with_retry(
-        f"{API}/search/issues", headers,
-        {"q": f"commenter:{user} org:{org}", "sort": "updated", "order": "desc", "per_page": 1},
-    )
-    if not data or data.get("total_count", 0) == 0:
-        return None
-    date_str = data["items"][0]["updated_at"]
-    return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
-
-
 def days_since_last_activity(org, user, token):
     headers = {
         "Accept": "application/vnd.github+json",
@@ -67,7 +56,7 @@ def days_since_last_activity(org, user, token):
     }
 
     dates = []
-    for fetch in (get_latest_commit_date, get_latest_issue_date, get_latest_comment_date):
+    for fetch in (get_latest_commit_date, get_latest_issue_date):
         dt = fetch(org, user, headers)
         if dt:
             dates.append(dt)

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -17,20 +17,34 @@ def gh_get(url, token, params=None):
     return r.json()
 
 
-def get_all_repos(org, token):
-    repos = []
-    page = 1
-    while True:
-        batch = gh_get(
-            f"{API}/orgs/{org}/repos",
-            token,
-            params={"per_page": 100, "page": page, "type": "all"},
-        )
-        if not batch:
-            break
-        repos.extend(batch)
-        page += 1
-    return repos
+def get_pinned_repos(org, token):
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    query = """
+    query($org: String!) {
+      organization(login: $org) {
+        pinnedItems(first: 6, types: REPOSITORY) {
+          nodes {
+            ... on Repository {
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+    r = requests.post(
+        "https://api.github.com/graphql",
+        headers=headers,
+        json={"query": query, "variables": {"org": org}},
+        timeout=30,
+    )
+    r.raise_for_status()
+    data = r.json()
+    nodes = data["data"]["organization"]["pinnedItems"]["nodes"]
+    return [{"name": n["name"]} for n in nodes]
 
 
 def get_latest_commit_date(org, repo, user, token):
@@ -47,7 +61,7 @@ def get_latest_commit_date(org, repo, user, token):
 
 
 def days_since_last_commit(org, user, token):
-    repos = get_all_repos(org, token)
+    repos = get_pinned_repos(org, token)
 
     latest_date = None
     latest_repo = None

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import time
 import requests
 from datetime import datetime, timezone
 
@@ -47,17 +48,22 @@ def get_pinned_repos(org, token):
     return [{"name": n["name"]} for n in nodes]
 
 
-def get_latest_commit_date(org, repo, user, token):
-    commits = gh_get(
-        f"{API}/repos/{org}/{repo}/commits",
-        token,
-        params={"author": user, "per_page": 1},
-    )
-    if not commits:
-        return None
-
-    # commit.author.date is ISO8601
-    return commits[0]["commit"]["author"]["date"]
+def get_latest_commit_date(org, repo, user, token, retries=3):
+    for attempt in range(retries):
+        try:
+            commits = gh_get(
+                f"{API}/repos/{org}/{repo}/commits",
+                token,
+                params={"author": user, "per_page": 1},
+            )
+            if not commits:
+                return None
+            return commits[0]["commit"]["author"]["date"]
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code >= 500 and attempt < retries - 1:
+                time.sleep(2 ** attempt)
+                continue
+            return None
 
 
 def days_since_last_commit(org, user, token):

--- a/scripts/days_since_last_commit.py
+++ b/scripts/days_since_last_commit.py
@@ -14,7 +14,7 @@ def days_since_last_commit(org, user, token):
         "User-Agent": "org-last-commit-check",
     }
 
-    for attempt in range(3):
+    for attempt in range(5):
         r = requests.get(
             f"{API}/search/commits",
             headers=headers,
@@ -23,9 +23,9 @@ def days_since_last_commit(org, user, token):
         )
 
         if r.status_code == 403:
-            # Secondary rate limit - wait and retry
-            retry_after = int(r.headers.get("Retry-After", 2 ** (attempt + 1)))
-            print(f"Rate limited for {user}, retrying in {retry_after}s...", file=sys.stderr)
+            # Secondary rate limit - use Retry-After or exponential backoff (10s, 20s, 40s, 80s, 160s)
+            retry_after = int(r.headers.get("Retry-After", 10 * (2 ** attempt)))
+            print(f"Rate limited for {user}, retrying in {retry_after}s (attempt {attempt + 1}/5)...", file=sys.stderr)
             time.sleep(retry_after)
             continue
 


### PR DESCRIPTION
## Summary
- Add error handling and validation to prevent empty/broken JSON from overwriting good data on the `data` branch
- Add `Last_Name` field support for maintainers — falls back to `Last_Name` when `First_Name` is empty
- Quote secret variable expansions, validate access token early, add `--fail` to curl calls
- Deduplicate partner summary rendering into a loop, reduce `fetch-depth` to 1
- Remove `-border` suffix from partner logo URLs

## Test plan
- [x] Trigger workflow manually and verify partners.json and maintainers.json are generated correctly
- [x] Verify maintainers with only Last_Name set get it used as First_Name
- [x] Confirm workflow fails gracefully when Zoho token is invalid
- [x] Confirm workflow refuses to commit empty JSON files