### PR TITLE
Add board_introduced field to reusable boards and JSON output

### DIFF
--- a/release-targets/reusable.yml
+++ b/release-targets/reusable.yml
@@ -32,6 +32,7 @@
 #   board_name      : Human-readable display name
 #   board_vendor    : Vendor/company slug (must match Zoho Bigin company_slug)
 #   board_support   : Support level - "conf", "csc", "wip", or "tvb"
+#   board_introduced: Year the board first came to market (e.g., "2022")
 #   uses            : Board slug to reuse artifacts from (e.g., "uefi-arm64")
 #
 # Optional Filters:
@@ -121,6 +122,7 @@ boards:
     board_name: "Minisforum MS-R1"
     board_vendor: "minisforum"
     board_support: "conf"
+    board_introduced: "2024"
 
     # The magic: reuse artifact set
     uses: "uefi-arm64"
@@ -131,6 +133,7 @@ boards:
     board_name: "Khadas Mind Series"
     board_vendor: "khadas"
     board_support: "conf"
+    board_introduced: "2024"
 
     # The magic: reuse artifact set
     uses: "uefi-x86"
@@ -141,6 +144,7 @@ boards:
     board_name: "Orangepi 6 Plus"
     board_vendor: "xunlong"
     board_support: "csc"
+    board_introduced: "2025"
 
     # The magic: reuse artifact set
     uses: "uefi-arm64"
@@ -151,6 +155,7 @@ boards:
     board_name: "Raspberry Pi Zero 2W"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2021"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -161,6 +166,7 @@ boards:
     board_name: "Raspberry Pi 3A+"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2018"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -171,6 +177,7 @@ boards:
     board_name: "Raspberry Pi 3B+"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2018"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -181,6 +188,7 @@ boards:
     board_name: "Raspberry Pi 3B"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2016"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -191,6 +199,7 @@ boards:
     board_name: "Raspberry Pi CM"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2014"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -201,6 +210,7 @@ boards:
     board_name: "Raspberry Pi CM3+"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2019"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -211,6 +221,7 @@ boards:
     board_name: "Raspberry Pi 400"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2020"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -221,6 +232,7 @@ boards:
     board_name: "Raspberry Pi 500"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2024"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -231,6 +243,7 @@ boards:
     board_name: "Raspberry Pi 500+"
     board_vendor: "rpi-foundation"
     board_support: "conf"
+    board_introduced: "2025"
 
     # The magic: reuse artifact set
     uses: "rpi4b"
@@ -241,6 +254,7 @@ boards:
     board_name: "Qidi X7"
     board_vendor: "makerbase"
     board_support: "csc"
+    board_introduced: "2025"
 
     # The magic: reuse artifact set
     uses: "qidi-x6"
@@ -251,6 +265,7 @@ boards:
     board_name: "Qidi X4"
     board_vendor: "makerbase"
     board_support: "csc"
+    board_introduced: "2024"
 
     # The magic: reuse artifact set
     uses: "qidi-x6"

--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -63,6 +63,7 @@ extract_cfg_var() {
 declare -A BOARD_NAME_MAP=()
 declare -A BOARD_VENDOR_MAP=()
 declare -A BOARD_SUPPORT_MAP=()
+declare -A BOARD_INTRODUCED_MAP=()
 
 MISSING_META_FILE="$(mktemp)"
 trap 'rm -f "$MISSING_META_FILE"' EXIT
@@ -73,12 +74,14 @@ while IFS= read -r cfg; do
 
   name="$(extract_cfg_var "$cfg" BOARD_NAME)"
   vendor="$(extract_cfg_var "$cfg" BOARD_VENDOR)"
+  introduced="$(extract_cfg_var "$cfg" INTRODUCED)"
   support="${cfg##*.}"; support="${support,,}"
 
 
   [[ -n "$name" ]]   && BOARD_NAME_MAP["$slug"]="$name"
   [[ -n "$vendor" ]] && BOARD_VENDOR_MAP["$slug"]="$vendor"
   [[ -n "$support" ]] && BOARD_SUPPORT_MAP["$slug"]="$support"
+  [[ -n "$introduced" ]] && BOARD_INTRODUCED_MAP["$slug"]="$introduced"
 
   if [[ -z "$name" || -z "$vendor" ]]; then
     printf '%s\n' "$slug" >>"$MISSING_META_FILE"
@@ -101,7 +104,7 @@ declare -A REUSABLE_BOARD_META=()       # board_slug -> "name|vendor|support"
 if [[ -f "$REUSABLE_FILE" ]]; then
   echo "▶ Loading reusable board definitions from ${REUSABLE_FILE}…" >&2
 
-  while IFS=$'\t' read -r slug name vendor support uses branch ext; do
+  while IFS=$'\t' read -r slug name vendor support uses branch ext introduced; do
     slug="${slug,,}"
     [[ -z "$slug" ]] && continue
 
@@ -115,6 +118,7 @@ if [[ -f "$REUSABLE_FILE" ]]; then
     [[ -n "$name" ]] && BOARD_NAME_MAP["$slug"]="$name"
     [[ -n "$vendor" ]] && BOARD_VENDOR_MAP["$slug"]="$vendor"
     [[ -n "$support" ]] && BOARD_SUPPORT_MAP["$slug"]="$support"
+    [[ -n "$introduced" ]] && BOARD_INTRODUCED_MAP["$slug"]="$introduced"
 
     ext_msg="${ext:+ (ext: ${ext})}"
     echo "  - ${slug} → ${uses}${branch:+ (branch: ${branch})}${ext_msg}" >&2
@@ -132,7 +136,8 @@ try:
             str(b.get('board_support', '')),
             str(b.get('uses', '')),
             str(b.get('branch', '')),
-            str(b.get('file_extension', ''))
+            str(b.get('file_extension', '')),
+            str(b.get('board_introduced', ''))
         ]))
 except Exception as e:
     sys.stderr.write(f'Error loading reusable.yml: {e}\n')
@@ -549,7 +554,7 @@ cat "$tmpdir/a.txt" "$tmpdir/bcd.txt" >"$feed"
 # JSON generation
 # -----------------------------------------------------------------------------
 {
-  echo '"board_slug"|"board_name"|"board_vendor"|"board_support"|"company_name"|"company_website"|"company_logo"|"armbian_version"|"file_url"|"file_url_asc"|"file_url_sha"|"file_url_torrent"|"redi_url"|"redi_url_asc"|"redi_url_sha"|"redi_url_torrent"|"file_size"|"file_date"|"distro"|"branch"|"variant"|"file_application"|"promoted"|"download_repository"|"file_extension"|"kernel_version"|"platinum"|"platinum_expired"|"platinum_until"'
+  echo '"board_slug"|"board_name"|"board_vendor"|"board_support"|"board_introduced"|"company_name"|"company_website"|"company_logo"|"armbian_version"|"file_url"|"file_url_asc"|"file_url_sha"|"file_url_torrent"|"redi_url"|"redi_url_asc"|"redi_url_sha"|"redi_url_torrent"|"file_size"|"file_date"|"distro"|"branch"|"variant"|"file_application"|"promoted"|"download_repository"|"file_extension"|"kernel_version"|"platinum"|"platinum_expired"|"platinum_until"'
 
   while IFS="|" read -r SIZE URL DATE; do
     IMAGE_SIZE="${SIZE//[.,]/}"
@@ -682,7 +687,7 @@ cat "$tmpdir/a.txt" "$tmpdir/bcd.txt" >"$feed"
         PLAT_EXPIRED="false"
       fi
     fi
-    echo "${BOARD_SLUG}|${BOARD_NAME_MAP[$BOARD_SLUG]:-}|${BOARD_VENDOR}|${BOARD_SUPPORT}|${C_NAME}|${C_WEB}|${C_LOGO}|${VER}|${FILE_URL}|${ASC}|${SHA}|${TOR}|${REDI_URL}|${REDI_URL}.asc|${REDI_URL}.sha|${REDI_URL}.torrent|${IMAGE_SIZE}|${DATE}|${DISTRO}|${BRANCH}|${VARIANT}|${APP}|${PROMOTED}|${REPO}|${FILE_EXTENSION}|${KERNEL_VERSION}|${PLAT}|${PLAT_EXPIRED}|${PLAT_UNTIL}"
+    echo "${BOARD_SLUG}|${BOARD_NAME_MAP[$BOARD_SLUG]:-}|${BOARD_VENDOR}|${BOARD_SUPPORT}|${BOARD_INTRODUCED_MAP[$BOARD_SLUG]:-}|${C_NAME}|${C_WEB}|${C_LOGO}|${VER}|${FILE_URL}|${ASC}|${SHA}|${TOR}|${REDI_URL}|${REDI_URL}.asc|${REDI_URL}.sha|${REDI_URL}.torrent|${IMAGE_SIZE}|${DATE}|${DISTRO}|${BRANCH}|${VARIANT}|${APP}|${PROMOTED}|${REPO}|${FILE_EXTENSION}|${KERNEL_VERSION}|${PLAT}|${PLAT_EXPIRED}|${PLAT_UNTIL}"
 
     # Check if this board is used by any reusable boards
     for reusable_slug in "${!REUSABLE_BOARD_USES[@]}"; do
@@ -766,7 +771,7 @@ cat "$tmpdir/a.txt" "$tmpdir/bcd.txt" >"$feed"
         fi
 
         # Output for reusable board
-        echo "${reusable_slug}|${reusable_name}|${reusable_vendor}|${reusable_support}|${reusable_c_name}|${reusable_c_web}|${reusable_c_logo}|${VER}|${FILE_URL}|${reusable_asc}|${reusable_sha}|${reusable_tor}|${reusable_redi_url}|${reusable_redi_url}.asc|${reusable_redi_url}.sha|${reusable_redi_url}.torrent|${IMAGE_SIZE}|${DATE}|${DISTRO}|${BRANCH}|${VARIANT}|${APP}|${reusable_promoted}|${REPO}|${FILE_EXTENSION}|${KERNEL_VERSION}|${reusable_plat}|${reusable_plat_expired}|${reusable_plat_until}"
+        echo "${reusable_slug}|${reusable_name}|${reusable_vendor}|${reusable_support}|${BOARD_INTRODUCED_MAP[$reusable_slug]:-}|${reusable_c_name}|${reusable_c_web}|${reusable_c_logo}|${VER}|${FILE_URL}|${reusable_asc}|${reusable_sha}|${reusable_tor}|${reusable_redi_url}|${reusable_redi_url}.asc|${reusable_redi_url}.sha|${reusable_redi_url}.torrent|${IMAGE_SIZE}|${DATE}|${DISTRO}|${BRANCH}|${VARIANT}|${APP}|${reusable_promoted}|${REPO}|${FILE_EXTENSION}|${KERNEL_VERSION}|${reusable_plat}|${reusable_plat_expired}|${reusable_plat_until}"
       fi
     done
   done <"$feed"


### PR DESCRIPTION
## Summary
- Adds `board_introduced` year field to all 15 reusable board entries in `reusable.yml`
- Updates `generate-armbian-images-json.sh` to extract `INTRODUCED` from board configs and `board_introduced` from reusable.yml, and include it in the JSON output

## Test plan
- [ ] Verify JSON generator includes `board_introduced` for base and reusable boards
- [ ] Spot-check years against known release dates