### PR TITLE
Add NanoPC T6 LTS Plus as reusable board

### DIFF
--- a/release-targets/reusable.yml
+++ b/release-targets/reusable.yml
@@ -255,4 +255,13 @@ boards:
     # The magic: reuse artifact set
     uses: "qidi-x6"
     branch: "current"
-    file_extension: "img.xz" 
+    file_extension: "img.xz"
+
+  - board_slug: "nanopct6-lts-plus"
+    board_name: "NanoPC T6 LTS Plus"
+    board_vendor: "friendlyelec"
+    board_support: "conf"
+
+    # The magic: reuse artifact set
+    uses: "nanopct6-lts"
+    file_extension: "img.xz"


### PR DESCRIPTION
## Summary
- Adds a virtual board entry `nanopct6-lts-plus` to `release-targets/reusable.yml`
- Reuses the `nanopct6-lts` artifact set under the `friendlyelec` vendor
- Filtered to `img.xz` files

## Test plan
- [ ] Regenerate `armbian-images.json` and verify the new entry appears
- [ ] Confirm vendor metadata (friendlyelec) and REDI URLs use the virtual board slug