### PR TITLE
nightly: bump Ubuntu release from plucky/noble to resolute

### DIFF
--- a/release-targets/targets-release-nightly.manual
+++ b/release-targets/targets-release-nightly.manual
@@ -9,7 +9,7 @@ minimal-cli-stable-ubuntu-cloud:
     gha: *armbian-gha
   build-image: "yes"
   vars:
-    RELEASE: plucky
+    RELEASE: resolute
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:

--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -1072,9 +1072,9 @@ def generate_nightly_yaml(conf_wip_boards, manual_content=""):
     """
     Generate nightly.yml with:
     - One minimal Debian Forky CLI image for all boards
-    - For fast HDMI: Ubuntu Noble GNOME desktop
-    - For slow HDMI: Ubuntu Noble XFCE desktop
-    - For headless and exotics (riscv64, loongarch): Ubuntu Noble minimal CLI
+    - For fast HDMI: Ubuntu Resolute GNOME desktop
+    - For slow HDMI: Ubuntu Resolute XFCE desktop
+    - For headless and exotics (riscv64, loongarch): Ubuntu Resolute minimal CLI
     One image per board for conf/wip boards.
     Separates fast, slow, riscv64, loongarch, and headless boards based on CPU performance.
     manual_content: Additional YAML to append inside the targets section
@@ -1156,15 +1156,15 @@ targets:
         yaml += '      - *nightly-loongarch\n'
 
     yaml += """
-  # Ubuntu noble GNOME desktop for fast HDMI boards
-  nightly-noble-gnome:
+  # Ubuntu resolute GNOME desktop for fast HDMI boards
+  nightly-resolute-gnome:
     enabled: yes
     configs: [ armbian-images ]
     pipeline:
       gha: *armbian-gha
     build-image: "yes"
     vars:
-      RELEASE: noble
+      RELEASE: resolute
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "gnome"
@@ -1174,18 +1174,18 @@ targets:
       - *nightly-fast-hdmi
 """
 
-    # Ubuntu noble XFCE desktop for slow HDMI boards
+    # Ubuntu resolute XFCE desktop for slow HDMI boards
     if slow_boards:
         yaml += """
-  # Ubuntu noble XFCE desktop for slow HDMI boards
-  nightly-noble-xfce:
+  # Ubuntu resolute XFCE desktop for slow HDMI boards
+  nightly-resolute-xfce:
     enabled: yes
     configs: [ armbian-images ]
     pipeline:
       gha: *armbian-gha
     build-image: "yes"
     vars:
-      RELEASE: noble
+      RELEASE: resolute
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
@@ -1195,18 +1195,18 @@ targets:
       - *nightly-slow-hdmi
 """
 
-    # Ubuntu noble XFCE desktop for RISC-V boards
+    # Ubuntu resolute XFCE desktop for RISC-V boards
     if riscv64_boards:
         yaml += """
-  # Ubuntu noble XFCE desktop for RISC-V boards
-  nightly-noble-riscv64-xfce:
+  # Ubuntu resolute XFCE desktop for RISC-V boards
+  nightly-resolute-riscv64-xfce:
     enabled: yes
     configs: [ armbian-images ]
     pipeline:
       gha: *armbian-gha
     build-image: "yes"
     vars:
-      RELEASE: noble
+      RELEASE: resolute
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
@@ -1216,25 +1216,25 @@ targets:
       - *nightly-riscv64
 """
 
-    # Ubuntu noble minimal CLI for headless boards only
+    # Ubuntu resolute minimal CLI for headless boards only
     if headless_boards:
         yaml += """
-  # Ubuntu noble minimal CLI for headless boards
-  nightly-noble-minimal:
+  # Ubuntu resolute minimal CLI for headless boards
+  nightly-resolute-minimal:
     enabled: yes
     configs: [ armbian-images ]
     pipeline:
       gha: *armbian-gha
     build-image: "yes"
     vars:
-      RELEASE: noble
+      RELEASE: resolute
       BUILD_MINIMAL: "yes"
       BUILD_DESKTOP: "no"
     items:
       - *nightly-headless
 """
 
-    # Note: loongarch boards don't get noble images, only bookworm minimal
+    # Note: loongarch boards don't get resolute images, only bookworm minimal
 
     if manual_content:
         # Indent manual content by 2 spaces to be under targets:


### PR DESCRIPTION
## Summary

Plucky (25.04) reached EOL on 2026-01-25 and resolute (26.04 LTS) just promoted to `supported` in [armbian/build#9657](https://github.com/armbian/build/pull/9657). Bump the nightly Ubuntu track to match.

Two swaps, both scoped to nightly:

- **`release-targets/targets-release-nightly.manual`** — `minimal-cli-stable-ubuntu-cloud` flips `RELEASE: plucky` → `RELEASE: resolute`. The target is labelled "Ubuntu stable minimal cloud" but was pinned to an interim release; resolute is the newly-supported LTS.
- **`scripts/generate_targets.py`** — `generate_nightly_yaml()` now emits `nightly-resolute-{gnome,xfce,riscv64-xfce,minimal}` instead of `nightly-noble-*`. Target keys, `RELEASE` values, comments, docstring, and the trailing loongarch note are all updated.

**Intentionally untouched**: stable targets (`generate_stable_yaml`) and community targets (`generate_community_yaml`) both stay on noble. Once resolute is confirmed good on the nightly channel, the same swap can be repeated for stable/community in a follow-up.

Also still on plucky and intentionally out of scope here (not rolling):
- `scripts/generate-rpi-imager-json.py:30` — `UBUNTU_RELEASES` set (RPi imager filter)
- `scripts/generate-base-files-info-json.py:269` — base-files data harvest

## Test plan

- [x] Generated `nightly.yaml` contains `nightly-resolute-gnome`, `nightly-resolute-xfce`, `nightly-resolute-riscv64-xfce`, `nightly-resolute-minimal` (no `nightly-noble-*`)
- [x] `minimal-cli-stable-ubuntu-cloud` appendix target shows `RELEASE: resolute`
- [x] Stable / community sections remain unchanged (still noble)