### PR TITLE
nightly: blacklist gateway-dk

### DIFF
--- a/release-targets/targets-release-nightly.blacklist
+++ b/release-targets/targets-release-nightly.blacklist
@@ -24,3 +24,4 @@ mekotronics-r58-4x4
 mekotronics-r58hd
 dg-svr-865-tiny
 sk-am64b
+gateway-dk


### PR DESCRIPTION
## Summary

Adds `gateway-dk` to `release-targets/targets-release-nightly.blacklist`.

Upcoming Ubuntu and Debian are borked. Logs:

- https://paste.armbian.com/aweducubif
- https://paste.armbian.com/alezujulan

Ref: https://github.com/armbian/build/pull/9655

## Priority

Low

## Test plan

- [x] Next nightly run skips `gateway-dk`
- [x] Other boards in the matrix unaffected