### PR TITLE
json-generation: handle .tar.xz image archives

### DIFF
--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -366,7 +366,7 @@ split_desktop_tail() {
 }
 
 strip_img_ext() {
-  sed -E 's/(\.img(\.(xz|zst|gz))?)$//' <<<"$1"
+  sed -E 's/(\.img(\.(xz|zst|gz))?|\.tar\.(xz|zst|gz))$//' <<<"$1"
 }
 
 extract_file_extension() {

--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -467,6 +467,20 @@ extract_file_extension() {
     return
   fi
 
+  # tar archives (e.g. Arduino UNO Q images): *.tar.xz / *.tar.gz / *.tar.zst
+  if [[ "$n" == *.tar.xz ]]; then
+    echo "tar.xz"
+    return
+  fi
+  if [[ "$n" == *.tar.gz ]]; then
+    echo "tar.gz"
+    return
+  fi
+  if [[ "$n" == *.tar.zst ]]; then
+    echo "tar.zst"
+    return
+  fi
+
   # fallback
   echo "${n##*.}"
 }


### PR DESCRIPTION
Fixes part of armbian/armbian.github.io#277 (generator-side).

## Problem

Images shipped as `.tar.xz` (currently the Arduino UNO Q community builds — `gnome_desktop`, `kde-neon_desktop`, `minimal`) are mishandled in two places of `scripts/generate-armbian-images-json.sh`:

1. **`extract_file_extension()`** has no branch for `.tar.*`, so it falls through to the generic `${n##*.}` fallback and returns just `"xz"`. Downstream consumers (notably armbian-router's `loadMapJSON`) only insert map entries whose extension ends with `img.xz` or a registered `specialExtension`, so these images are silently dropped from the redirect map and every `redi_url` pointing to them 404s via the mirror.
2. **`strip_img_ext()`** only strips `.img(.xz|.zst|.gz)`, so kernel-suffix parsing for tar-based filenames doesn't correctly strip the extension.

## Fix (2 commits)

- `strip_img_ext`: extend the regex to also match `.tar.(xz|zst|gz)`.
- `extract_file_extension`: add explicit branches returning `tar.xz` / `tar.gz` / `tar.zst` before the fallback.

With these, tar-based artifacts now produce sensible `file_extension` values and downstream tools can treat them as first-class images.

## Companion PR

The router-side counterpart is in armbian/armbian-router#39 and must land together for the Arduino UNO Q `redi_url` entries to resolve correctly.

## Related

- armbian/armbian.github.io#277
- armbian/armbian-router#39

/cc @igorpecovnik @efectn