### PR TITLE
workflows: run external-package purge once per workflow, not per chunk

### DIFF
--- a/.github/workflows/infrastructure-download-external.yml
+++ b/.github/workflows/infrastructure-download-external.yml
@@ -93,7 +93,18 @@ jobs:
   preclean:
     name: "Purge"
     needs: perm
-    if: ${{ inputs.PURGE == true }}
+    # Purge only in chunk 0. The preclean/postclean pair doesn't use
+    # CHUNK_INDEX to filter its matrix — it builds the same
+    # (release × package) list on every chunk and runs repo.sh -c delete
+    # against /publishing/repository-debs. With 4 chunks that meant 4
+    # parallel invocations of aptly's delete op racing on the same
+    # repository state; aptly serialises via its own lockfile but the
+    # fanout is still pure waste at best and a corruption hazard when a
+    # held lock times out. Package download IS parallel-friendly (each
+    # chunk fetches its own slice of debs into /incoming/debs/external),
+    # but the repo-side purge is a single-threaded operation on shared
+    # state. Gate it to chunk 0 so it runs exactly once per workflow.
+    if: ${{ inputs.PURGE == true && inputs.CHUNK_INDEX == 0 }}
     runs-on: ubuntu-latest
     outputs:
       matrix:  ${{steps.json.outputs.JSON_CONTENT}}
@@ -124,7 +135,12 @@ jobs:
 
   postclean:
     needs: preclean
-    if: ${{ inputs.PURGE == true }}
+    # Same chunk-0 gate as preclean (see its comment): this is the
+    # repo.sh -c delete pass, which mutates shared aptly state and
+    # MUST run single-threaded. The inner matrix already has
+    # max-parallel: 1; the chunk gate here prevents 4 parallel
+    # copies of that same serialised matrix from racing each other.
+    if: ${{ inputs.PURGE == true && inputs.CHUNK_INDEX == 0 }}
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/infrastructure-download-external.yml
+++ b/.github/workflows/infrastructure-download-external.yml
@@ -152,6 +152,18 @@ jobs:
     runs-on: repository
     steps:
 
+      # Pre-chown before checkout. The Purge step below runs sudo
+      # against /publishing/repository-debs and against the runner's
+      # workspace-relative tools/repository/repo.sh output — both can
+      # leave root-owned files under $GITHUB_WORKSPACE, so a later
+      # non-root actions/checkout@v6 with clean: true (in the caller
+      # workflow's Copying job) fails with EACCES. Reclaim ownership
+      # first so the workspace is always deletable by the runner user.
+      - name: Fix workspace ownership
+        if: always()
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" "$GITHUB_WORKSPACE" || true
+
       - name: Checkout build repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/infrastructure-repository-update.yml
+++ b/.github/workflows/infrastructure-repository-update.yml
@@ -78,6 +78,20 @@ jobs:
     runs-on: repository
     steps:
 
+      # Reclaim workspace before the later actions/checkout@v6 runs
+      # with clean: true. The self-hosted `repository` runner pool is
+      # shared across workflows, and any previous run that left
+      # root-owned files under $GITHUB_WORKSPACE (e.g. the reusable
+      # download-external workflow's postclean, which runs sudo
+      # operations on the repo tree) would trip checkout's unlink
+      # with EACCES on files like build/.coderabbit.yaml. Same
+      # defensive chown the update-repository / Sync / Index jobs
+      # already do as their first step.
+      - name: Fix workspace ownership
+        if: always()
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" "$GITHUB_WORKSPACE" || true
+
       - name: Delete empty folders in INCOMING_PATH
         run: |
 
@@ -193,6 +207,12 @@ jobs:
     needs: Copying
     runs-on: repository
     steps:
+      # See Copying's identical step for rationale.
+      - name: Fix workspace ownership
+        if: always()
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" "$GITHUB_WORKSPACE" || true
+
       - name: Checkout build repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- `infrastructure-download-external.yml`'s `preclean` / `postclean` didn't use `CHUNK_INDEX` to filter. Both built the same `(release × package)` matrix on every chunk invocation and ran `repo.sh -c delete` against the shared `/publishing/repository-debs` repo.
- With the 4-chunk fanout in `infrastructure-repository-update.yml`, that was 4 parallel copies of aptly's delete op contending on the same repository state. aptly's lockfile usually saves it from corruption, but it's redundant work at best and a corruption hazard the moment a held lock times out or gets bypassed.
- Gate both jobs on `inputs.CHUNK_INDEX == 0` so the purge runs exactly once per workflow. Chunks 1..3 now skip `preclean` / `postclean` entirely and go straight to their slice of the download matrix.
- Download parallelism is preserved — the download step already slices via `CHUNK_INDEX` and is the reason for the 4-way fanout. Purge goes back to being the single-threaded operation aptly's data model requires.

## Test plan

- [x] Manual dispatch of `Infrastructure: APT repositories update` with `purge_external=true` — confirm `Purge` jobs show `completed` on chunk 0 only and `skipped` on chunks 1..3.
- [x] Confirm chunk 1..3's `Mirror` / download matrix jobs run as before (unaffected by the gate).
- [x] Confirm the `Purge old <pkg> from <release>` sub-matrix runs once per (release, package) tuple total, not 4× per tuple.
- [x] Post-run: aptly repo still lists the expected surviving versions of `code`, `google-chrome-stable`, etc. (one version each, older ones deleted).