### PR TITLE
targets: set DESKTOP_TIER per desktop block, keyed on DESKTOP_APPGROUPS_SELECTED

### DIFF
--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -902,6 +902,7 @@ targets:
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: "programming"
+      DESKTOP_TIER: "mid"
     items:
       - *stable-current-slow-hdmi
 """
@@ -927,6 +928,7 @@ targets:
       DESKTOP_ENVIRONMENT: "gnome"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: "programming"
+      DESKTOP_TIER: "mid"
     items:
 """
         if current_fast:
@@ -955,6 +957,7 @@ targets:
       DESKTOP_ENVIRONMENT: "kde-neon"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: "programming"
+      DESKTOP_TIER: "mid"
     items:
       - *stable-current-fast-hdmi
 """
@@ -980,6 +983,7 @@ targets:
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: "programming"
+      DESKTOP_TIER: "mid"
     items:
       - *stable-legacy-fast-hdmi
 """
@@ -1001,6 +1005,7 @@ targets:
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
 """
         if current_riscv64:
@@ -1170,6 +1175,7 @@ targets:
       DESKTOP_ENVIRONMENT: "gnome"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
       - *nightly-fast-hdmi
 """
@@ -1191,6 +1197,7 @@ targets:
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
       - *nightly-slow-hdmi
 """
@@ -1212,6 +1219,7 @@ targets:
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
       - *nightly-riscv64
 """
@@ -1453,6 +1461,7 @@ targets:
       DESKTOP_ENVIRONMENT: "gnome"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
       - *community-current-fast-hdmi
 """
@@ -1478,6 +1487,7 @@ targets:
       DESKTOP_ENVIRONMENT: "kde-neon"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
       - *community-current-fast-hdmi
 """
@@ -1503,6 +1513,7 @@ targets:
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
 """
         if current_slow:
@@ -1529,6 +1540,7 @@ targets:
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
 """
         if current_riscv64:


### PR DESCRIPTION
## Summary

armbian-config's `module_desktops` treats `minimal` / `mid` / `full` as three distinct install targets. The build framework hard-requires an explicit `DESKTOP_TIER` whenever `BUILD_DESKTOP=yes`; a missing value causes `module_desktops install` to bail at config-validation time.

`scripts/generate_targets.py` emits 12 `desktop-*` target blocks across the stable / legacy / edge / nightly flavours. None of them set `DESKTOP_TIER` today, so every regenerated `targets.yaml` will start failing desktop builds once the build-side migration (armbian/build#9683 — replace `config/desktop/` tree with armbian-config `module_desktops`) lands.

## Change

Add `DESKTOP_TIER` to every `desktop-*` block's `vars:` stanza, mapping the value from the existing `DESKTOP_APPGROUPS_SELECTED` that each block already carries:

| `DESKTOP_APPGROUPS_SELECTED` | → | `DESKTOP_TIER` | Blocks | Rough size |
|---|---|---|---|---|
| `""` (empty) | → | `minimal` | 8 | DE + display manager only (~500 MB) — matches the bare desktop the empty-appgroup target produced before |
| `"programming"` | → | `mid` | 4 | DE + browser + everyday user-facing tools (editor, calculator, media, archive, torrent, ~1 GB) — roughly what the `programming` appgroup pulled in on top of the bare desktop |

Neither maps to `full` — none of the current generate_targets.py blocks wanted the full tier (office suite + creative tools, ~2.5 GB). Future targets can override per block when needed.

## Diff shape

```diff
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
+      DESKTOP_TIER: "minimal"
     items:
```

```diff
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: "programming"
+      DESKTOP_TIER: "mid"
     items:
```

12 single-line insertions total; no structural edits.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('scripts/generate_targets.py').read())"` — syntax clean.
- [x] Module loads clean (no `SystemExit` / import-time errors).
- [x] Verified 8 `"minimal"` + 4 `"mid"` insertions, each directly below a matching `DESKTOP_APPGROUPS_SELECTED` line — no mis-pairings.
- [ ] Regenerate `targets.yaml` locally and confirm every `desktop-*` target carries the right `DESKTOP_TIER`.
- [ ] Build-side `module_desktops install` accepts the generated targets (needs armbian/build#9683 to be live).