### PR TITLE
Revert "Disable Sk-am64b as its not compiling on Resolute"

### DIFF
--- a/release-targets/targets-release-nightly.blacklist
+++ b/release-targets/targets-release-nightly.blacklist
@@ -23,5 +23,4 @@ uefi-x86
 mekotronics-r58-4x4
 mekotronics-r58hd
 dg-svr-865-tiny
-sk-am64b
 gateway-dk


### PR DESCRIPTION
Follow up from https://github.com/armbian/armbian.github.io/pull/280

This reverts commit 88bb841e47b4530ecf431e8ea1d56bc1f87c7706.

Issue should be fixed when bumping ti-linux-kernel to 6.18 kernel,
see d9761a239dfe088ba4d339851b946aa2ce9646d3 in armbian/build.

I was able to replicate build error with TI SDK tag 11.02.08 (kernel 6.12): https://paste.armbian.com/kasakutuqe 
But error not seen anymore using TI SDK tag 12.00.00.07 (kernel 6.18): https://paste.armbian.com/mezezaduhu 

@igorpecovnik `sk-am64b` should be fine to remove from blacklist now