### PR TITLE
workflows/hetzner: expose machine_count and server_type as dispatch inputs

### DIFF
--- a/.github/workflows/infrastructure-hetzner-runners.yml
+++ b/.github/workflows/infrastructure-hetzner-runners.yml
@@ -1,6 +1,27 @@
-name: "Infrastructure: Enable 16 Hetzner ARM64 runners"
+name: "Infrastructure: Enable Hetzner ARM64 runners"
 on:
   workflow_dispatch:
+    inputs:
+      machine_count:
+        description: "Number of Hetzner VMs to provision"
+        required: false
+        type: choice
+        default: "4"
+        options:
+          - "1"
+          - "2"
+          - "4"
+          - "8"
+          - "16"
+      server_type:
+        description: "Hetzner server type (auto-falls back on capacity shortage)"
+        required: false
+        type: choice
+        default: "cax41"
+        options:
+          - "cax41"
+          - "cax31"
+          - "cax21"
 
 concurrency:
   group: hetzner-runner
@@ -35,7 +56,11 @@ jobs:
       - name: Generate matrix
         id: matrix
         run: |
-          count=${{ env.MACHINE_COUNT || '4' }}
+          # inputs.* is populated on workflow_dispatch (UI / gh workflow run);
+          # empty when the workflow is triggered any other way (repository_dispatch,
+          # API without inputs, etc.). Fall back to 4 so the legacy "no args"
+          # call shape keeps working.
+          count=${{ inputs.machine_count || '4' }}
           echo "Generating matrix for ${count} server(s)"
           matrix=$(seq 0 $(( count - 1 )) | jq -cnR '[inputs | tonumber]')
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
@@ -59,7 +84,7 @@ jobs:
         uses: armbian/actions/hetzner@main
         with:
           action: create
-          server-type: "${{ env.MACHINE || 'cax41' }}"
+          server-type: "${{ inputs.server_type || 'cax41' }}"
           index: "${{ matrix.index }}"
           delete-existing: "true"
           ssh-key: "UPLOAD"
@@ -99,6 +124,6 @@ jobs:
         uses: armbian/actions/hetzner@main
         with:
           action: delete
-          server-type: "${{ env.MACHINE || 'cax41' }}"
+          server-type: "${{ inputs.server_type || 'cax41' }}"
           index: "${{ matrix.index }}"
           hetzner-token: ${{ secrets.HETZNER_ONE }}

--- a/.github/workflows/infrastructure-hetzner-runners.yml
+++ b/.github/workflows/infrastructure-hetzner-runners.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
 
       - name: Create Hetzner server
-        uses: armbian/actions/hetzner@hetzner-validate-github-token
+        uses: armbian/actions/hetzner@main
         with:
           action: create
           server-type: "${{ inputs.server_type || 'cax41' }}"

--- a/.github/workflows/infrastructure-hetzner-runners.yml
+++ b/.github/workflows/infrastructure-hetzner-runners.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
 
       - name: Create Hetzner server
-        uses: armbian/actions/hetzner@main
+        uses: armbian/actions/hetzner@hetzner-validate-github-token
         with:
           action: create
           server-type: "${{ inputs.server_type || 'cax41' }}"


### PR DESCRIPTION
## Summary

The Hetzner runner workflow advertised four knobs (`MACHINE`, `MACHINE_COUNT`, `RUNNER_COUNT`, `PERIOD`) in its original commit message but none were actually wired up — `workflow_dispatch` had no `inputs:` block, so `${{ env.MACHINE || 'cax41' }}` and `${{ env.MACHINE_COUNT || '4' }}` always evaluated to the default and the workflow name ("Enable 16 Hetzner ARM64 runners") was literally the only thing it could do.

First pass at making it configurable:

- **`machine_count`** — choice of `1`/`2`/`4`/`8`/`16`, default `4`. Matrix generator now reads `inputs.machine_count`.
- **`server_type`** — choice of `cax41`/`cax31`/`cax21`, default `cax41`. `Create` and `Cleaning` both pick it up. The action auto-falls back to a smaller type on capacity shortage, so this is "biggest you're willing to wait for".

`|| '<default>'` fallbacks are kept so `repository_dispatch` / REST API callers that omit inputs keep working as before.

Workflow renamed to drop the "16" — it's now variable.

## Out of scope (follow-ups)

- `RUNNER_COUNT` and `PERIOD` are still hardcoded; wiring those is a separate pass.
- The "Hetzner VMs come up but runners don't register" issue we hit last run — needs an actual `armbian-config` / `HETZNER_RUNNER` token investigation; not a workflow-shape problem.

## Test plan

- [ ] Trigger via UI with all defaults → 4 × cax41 as before
- [ ] Trigger via UI with machine_count=2, server_type=cax31 → 2 × cax31
- [ ] Trigger via REST API without any inputs → falls back to 4 × cax41 (verifies the \`|| '<default>'\` path)