### PR TITLE
release-targets: add radxa-dragon-q6a and radxa-nio-12l with ufs extension

### DIFF
--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -19,6 +19,8 @@ minimal-stable-debian-uefi:
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
+    - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
+    - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
 # Ubuntu noble minimal with current kernel - UEFI only
 minimal-stable-ubuntu-current-uefi:
@@ -38,6 +40,8 @@ minimal-stable-ubuntu-current-uefi:
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
+    - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
+    - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
 # Ubuntu noble GNOME desktop - UEFI only
 desktop-stable-ubuntu-gnome-uefi:
@@ -57,6 +61,8 @@ desktop-stable-ubuntu-gnome-uefi:
     - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
     - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu,nvidia" }
     - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
+    - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
+    - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
 # Ubuntu noble Cinnamon desktop - UEFI only
 desktop-stable-ubuntu-cinnamon-uefi:
@@ -76,3 +82,5 @@ desktop-stable-ubuntu-cinnamon-uefi:
     - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
     - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu,nvidia" }
     - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
+    - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
+    - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }


### PR DESCRIPTION
## Summary

Add two new Qualcomm / MediaTek ARM64 boards with UFS storage to `targets-release-standard-support.manual`:

| Board | BOARDFAMILY | BRANCH |
|---|---|---|
| `radxa-dragon-q6a` | `qcs6490` | `current` |
| `radxa-nio-12l`    | `genio`   | `edge`    |

Both boards ship with UFS as their primary storage, so enable [`extensions/ufs.sh`](https://github.com/armbian/build/blob/main/extensions/ufs.sh) — creates a UFS-aligned image (requires `sfdisk >= 2.41` from util-linux on the build host).

Added to **all four** existing standard-support blocks:

- `minimal-stable-debian-uefi` — Debian trixie minimal
- `minimal-stable-ubuntu-current-uefi` — Ubuntu noble minimal
- `desktop-stable-ubuntu-gnome-uefi` — Ubuntu noble GNOME
- `desktop-stable-ubuntu-cinnamon-uefi` — Ubuntu noble Cinnamon

The "-uefi" suffix on these blocks is a category label, not a hard constraint — `thinkpad-x13s` (also a non-UEFI Qualcomm board) is already added to the two desktop blocks under the same convention.

## Test plan
- [ ] Next release run picks up both boards across all four blocks
- [ ] `ufs` extension successfully produces UFS-aligned images for both
- [ ] Produced images boot on the target hardware