### PR TITLE
generate-armbian-images-json: detect preinstalled app past kernel rc/beta tag

### DIFF
--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -555,11 +555,22 @@ parse_image_name() {
   fi
 
   if [[ "$kernel" == *-* ]]; then
-    suffix="$(strip_img_ext "${kernel#*-}")"
+    # Use longest match from left (`##*-`) so that kernel fields with
+    # rc / beta / snapshot markers in the middle still pick up the
+    # *last* dash-separated token. Examples:
+    #   6.19.0-rc5-omv   → "omv"   (not "rc5-omv", which the shortest
+    #                               match would produce and which then
+    #                               fails the whole-string
+    #                               is_preinstalled_app case match)
+    #   6.6.62-omv       → "omv"
+    #   6.6.62-current   → "current" (not a preinstalled app, no ufs,
+    #                                 app stays empty)
+    #   6.19.0-rc5-ufs   → "ufs"
+    suffix="$(strip_img_ext "${kernel##*-}")"
     if is_preinstalled_app "$suffix"; then
       app="$suffix"
     else
-      [[ "${suffix##*-}" == "ufs" ]] && app="ufs"
+      [[ "$suffix" == "ufs" ]] && app="ufs"
     fi
   fi
 


### PR DESCRIPTION
## Summary

`parse_image_name` in `scripts/generate-armbian-images-json.sh` extracts the preinstalled-app suffix (`kali` / `homeassistant` / `openhab` / `omv` / `ufs`) from the kernel field of the image filename. It was doing this with `${kernel#*-}`, which strips only the shortest prefix up to the **first** dash.

That works on two-segment kernel fields (`6.6.62-omv`) but breaks as soon as an upstream release marker lands between the version and the app suffix:

```
6.19.0-rc5-omv  →  ${kernel#*-}  =  "rc5-omv"
```

`is_preinstalled_app "rc5-omv"` matches the whole argument against the `kali|homeassistant|openhab|omv` case statement — so it misses. The fallback UFS check looks at the *last* token via `${suffix##*-}` (`"omv"`) but only compares against the literal `"ufs"`, so it also misses. Net result: `app=""` on every three-segment kernel field.

Concrete example from production:

```json
{
  "file_url": ".../Armbian_26.2.1_Radxa-nio-12l_trixie_collabora_6.19.0-rc5-omv_minimal.img.xz",
  "variant": "minimal",
  "branch": "collabora",
  "file_application": ""
}
```

## Change

Switch to `${kernel##*-}` (longest match from left) so `suffix` is always the final dash-separated token. Collapse the UFS fallback to compare against `$suffix` directly — now that `suffix` is already the last token, the extra `##*-` strip becomes redundant.

## Verified

| Kernel field | Old `app` | New `app` |
|---|---|---|
| `6.6.62-omv` | `omv` | `omv` |
| `6.19.0-rc5-omv` | `""` (bug) | `omv` ✓ |
| `6.19.0-rc5-ufs` | `""` (bug) | `ufs` ✓ |
| `6.19.0-rc5` | `""` | `""` |
| `6.6.62-current` | `""` | `""` |

No regression on any two-segment kernel name; three-segment names now parse correctly.