### PR TITLE
Fix workflow bugs and add AI cover image generation

### DIFF
--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -325,9 +325,11 @@ jobs:
           - optional small caption: "{tagline}"
 
           COMPOSITION:
+          - ultrawide cinematic format (21:9 aspect ratio)
           - left or center weighted
           - strong focal object (board / chip / abstract system)
-          - space for readable text overlay
+          - expansive negative space for text overlay
+          - panoramic, sweeping composition
 
           QUALITY:
           - ultra sharp, production-ready marketing image
@@ -346,7 +348,7 @@ jobs:
                   config=types.GenerateContentConfig(
                       response_modalities=['IMAGE'],
                       image_config=types.ImageConfig(
-                          aspect_ratio="16:9",
+                          aspect_ratio="21:9",
                           image_size="2K"
                       )
                   )
@@ -421,7 +423,7 @@ jobs:
               echo "| **File** | cover.png |"
               echo "| **Size** | ${IMAGE_SIZE} |"
               echo "| **Model** | Gemini 3.1 Flash Image Preview |"
-              echo "| **Resolution** | 2752×1536 (2K, 16:9) |"
+              echo "| **Resolution** | 3168×1344 (2K, 21:9 ultrawide) |"
               echo "| **Release Attachment** | ✅ Yes |"
               echo ""
               echo "<details>"

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -376,6 +376,14 @@ jobs:
               sys.exit(0)
           PY
 
+      - name: Upload cover image as artifact
+        if: hashFiles('cover.png') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: cover-image
+          path: cover.png
+          if-no-files-found: ignore
+
       - name: Check if cover image exists
         id: check_cover
         run: |
@@ -388,24 +396,47 @@ jobs:
       - name: Add cover image to workflow summary
         if: steps.check_cover.outputs.exists == 'true'
         run: |
-          {
-            echo "## 🎨 Generated Cover Image"
-            echo ""
-            echo "### Preview"
-            echo ""
-            echo "![Cover Image](cover.png)"
-            echo ""
-            echo "<details>"
-            echo "<summary>Image details</summary>"
-            echo ""
-            echo "- **File**: cover.png"
-            echo "- **Attached to release**: Yes"
-            echo "- **Model**: Gemini 3.1 Flash Image Preview"
-            echo "- **Resolution**: 2752x1536 (2K, 16:9)"
-            echo ""
-            echo "</details>"
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
+          # Get absolute path for the image
+          IMAGE_PATH="${GITHUB_WORKSPACE}/cover.png"
+
+          # Verify image exists and get its size
+          if [ -f "$IMAGE_PATH" ]; then
+            IMAGE_SIZE=$(ls -lh "$IMAGE_PATH" | awk '{print $5}')
+            ARTIFACTS_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts"
+
+            # Add to workflow summary
+            {
+              echo "## 🎨 Generated Cover Image"
+              echo ""
+              echo "### 📥 Download & View"
+              echo ""
+              echo "🔽 **Download**: [cover.png](../../artifacts) (available in workflow artifacts)"
+              echo ""
+              echo "📦 **All artifacts**: [View artifacts](${ARTIFACTS_URL})"
+              echo ""
+              echo "### 📊 Image Details"
+              echo ""
+              echo "| Property | Value |"
+              echo "|----------|-------|"
+              echo "| **File** | cover.png |"
+              echo "| **Size** | ${IMAGE_SIZE} |"
+              echo "| **Model** | Gemini 3.1 Flash Image Preview |"
+              echo "| **Resolution** | 2752×1536 (2K, 16:9) |"
+              echo "| **Release Attachment** | ✅ Yes |"
+              echo ""
+              echo "<details>"
+              echo "<summary>Technical information</summary>"
+              echo ""
+              echo "- **Workspace path**: \`${IMAGE_PATH}\`"
+              echo "- **Artifact name**: \`cover-image\`"
+              echo "- **Workflow run**: \`${GITHUB_RUN_ID}\`"
+              echo ""
+              echo "</details>"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ Cover image not found at ${IMAGE_PATH}" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - uses: ncipollo/release-action@v1
         if: ${{ env.RELEASE_ENABLED == 'true' }}

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -385,6 +385,28 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Add cover image to workflow summary
+        if: steps.check_cover.outputs.exists == 'true'
+        run: |
+          {
+            echo "## 🎨 Generated Cover Image"
+            echo ""
+            echo "### Preview"
+            echo ""
+            echo "![Cover Image](cover.png)"
+            echo ""
+            echo "<details>"
+            echo "<summary>Image details</summary>"
+            echo ""
+            echo "- **File**: cover.png"
+            echo "- **Attached to release**: Yes"
+            echo "- **Model**: Gemini 3.1 Flash Image Preview"
+            echo "- **Resolution**: 2752x1536 (2K, 16:9)"
+            echo ""
+            echo "</details>"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: ncipollo/release-action@v1
         if: ${{ env.RELEASE_ENABLED == 'true' }}
         with:

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -254,16 +254,23 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           set -euo pipefail
+          # NOTE: Gemini 3.1 Flash Image Preview requires PAID TIER
+          # Free tier does not support image generation (quota: 0)
+          # To enable: Add GEMINI_API_KEY secret with paid tier key
+          # Get key: https://aistudio.google.com/app/apikey
+          # Pricing: https://ai.google.dev/gemini-api/docs/pricing
           python3 <<'PY'
           import os
+          import sys
           from google import genai
           from google.genai import types
+          from google.genai.errors import ClientError
 
           # Check if API key is available
           token = os.environ.get("GEMINI_API_KEY")
           if not token:
               print("GEMINI_API_KEY not set - skipping image generation")
-              exit(0)
+              sys.exit(0)
 
           label = os.environ["LABEL"]
 
@@ -331,29 +338,52 @@ jobs:
           # Initialize the client
           client = genai.Client(api_key=token)
 
-          # Generate the image
-          response = client.models.generate_content(
-              model="gemini-3.1-flash-image-preview",
-              contents=[prompt],
-              config=types.GenerateContentConfig(
-                  response_modalities=['IMAGE'],
-                  image_config=types.ImageConfig(
-                      aspect_ratio="16:9",
-                      image_size="2K"
+          try:
+              # Generate the image
+              response = client.models.generate_content(
+                  model="gemini-3.1-flash-image-preview",
+                  contents=[prompt],
+                  config=types.GenerateContentConfig(
+                      response_modalities=['IMAGE'],
+                      image_config=types.ImageConfig(
+                          aspect_ratio="16:9",
+                          image_size="2K"
+                      )
                   )
               )
-          )
 
-          # Save the generated image
-          for part in response.parts:
-              if hasattr(part, 'inline_data') and part.inline_data is not None:
-                  image = part.as_image()
-                  image.save("cover.png")
-                  print("Cover image generated successfully: cover.png")
-                  break
-          else:
-              print("No image generated - this may indicate an API error")
+              # Save the generated image
+              for part in response.parts:
+                  if hasattr(part, 'inline_data') and part.inline_data is not None:
+                      image = part.as_image()
+                      image.save("cover.png")
+                      print("Cover image generated successfully: cover.png")
+                      break
+              else:
+                  print("No image generated - this may indicate an API error")
+                  sys.exit(0)
+
+          except ClientError as e:
+              if e.status_code == 429:
+                  print("Image generation skipped: Gemini image model requires paid tier (free tier quota exceeded)")
+                  print("To enable: https://ai.google.dev/gemini-api/docs/pricing")
+                  sys.exit(0)
+              else:
+                  print(f"API error: {e}")
+                  sys.exit(0)
+          except Exception as e:
+              print(f"Image generation failed: {e}")
+              sys.exit(0)
           PY
+
+      - name: Check if cover image exists
+        id: check_cover
+        run: |
+          if [ -f "cover.png" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
 
       - uses: ncipollo/release-action@v1
         if: ${{ env.RELEASE_ENABLED == 'true' }}
@@ -366,7 +396,7 @@ jobs:
           prerelease: "false"
           makeLatest: "true"
           bodyFile: "summary.md"
-          artifacts: "cover.png"
+          artifacts: ${{ steps.check_cover.outputs.exists == 'true' && 'cover.png' || '' }}
           allowUpdates: "true"
           skipIfReleaseExists: "true"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -397,7 +397,7 @@ jobs:
                       response_modalities=['IMAGE'],
                       image_config=types.ImageConfig(
                           aspect_ratio="21:9",
-                          image_size="2K"
+                          image_size="1K"
                       )
                   )
               )

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -267,23 +267,65 @@ jobs:
 
           label = os.environ["LABEL"]
 
-          # Read the summary to create a context-aware prompt
+          # Get current date for subtitle
+          from datetime import datetime
+          current_date = datetime.now().strftime("%B %d, %Y")
+
+          # Read the summary to extract key themes
           with open("summary.md", "r", encoding="utf-8") as f:
               summary_content = f.read().strip()
 
-          # Create a prompt for cover image generation
-          # Focus on visual representation of the digest type
-          prompt = f"""Create a modern, minimalist cover image for an Armbian {label.lower()}.
+          # Extract tagline based on content
+          import re
+          pr_count = len(re.findall(r'^\*', summary_content, re.MULTILINE))
+          if pr_count > 20:
+              tagline = f"{pr_count} contributions • Community driven"
+          elif pr_count > 10:
+              tagline = f"{pr_count} updates • Open source"
+          else:
+              tagline = "Building the future"
 
-          Style guidelines:
-          - Clean, tech-focused aesthetic with subtle gradients
-          - Include Armbian branding elements (use blue tones)
-          - Add the text "{label}" in a modern, bold sans-serif font
-          - Include subtle circuit board or motherboard patterns in the background
-          - Aspect ratio: 16:9 (landscape)
-          - Resolution: 2K
-          - Professional software release style
-          - Leave some negative space for potential overlay text
+          # Determine digest type for title
+          digest_title = "Armbian Weekly" if "weekly" in label.lower() else "Armbian Monthly"
+
+          # Dynamic content focus based on PR themes
+          content_focus = """embedded Linux ecosystem, single-board computing, kernel development,
+          system infrastructure, and community-driven innovation"""
+
+          # Create a high-end, professional prompt
+          prompt = f"""Create a high-end, modern tech illustration in a consistent visual identity for {digest_title}.
+
+          STYLE:
+          - premium, minimalistic, futuristic
+          - dark background with soft gradients (navy, deep blue)
+          - strong orange accent highlights (Armbian identity)
+          - subtle glow, cinematic lighting
+          - isometric / semi-3D composition
+          - extremely clean, no clutter
+
+          BRANDING:
+          - inspired by embedded Linux, SBC boards, infrastructure
+          - abstract circuits, silicon, data flow, kernel layers
+          - DO NOT include any real logos
+          - consistent visual identity across weeks
+
+          CONTENT FOCUS:
+          {content_focus}
+
+          TEXT IN IMAGE:
+          - title: "{digest_title}"
+          - subtitle: "{current_date}"
+          - optional small caption: "{tagline}"
+
+          COMPOSITION:
+          - left or center weighted
+          - strong focal object (board / chip / abstract system)
+          - space for readable text overlay
+
+          QUALITY:
+          - ultra sharp, production-ready marketing image
+          - correct typography (no broken text)
+          - consistent style across all outputs
           """
 
           # Initialize the client

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install OpenAI SDK
         run: pip install 'openai>=1.0.0'
 
+      - name: Install Google Gen AI SDK
+        run: pip install 'google-genai>=1.0.0'
+
       - name: Ensure dependencies
         run: |
           sudo apt-get update
@@ -245,6 +248,71 @@ jobs:
       - name: "Output summary to step summary"
         run: cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: "Generate AI cover image"
+        if: ${{ env.PERIOD == 'weekly' || env.PERIOD == 'monthly' }}
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import os
+          from google import genai
+          from google.genai import types
+
+          # Check if API key is available
+          token = os.environ.get("GEMINI_API_KEY")
+          if not token:
+              print("GEMINI_API_KEY not set - skipping image generation")
+              exit(0)
+
+          label = os.environ["LABEL"]
+
+          # Read the summary to create a context-aware prompt
+          with open("summary.md", "r", encoding="utf-8") as f:
+              summary_content = f.read().strip()
+
+          # Create a prompt for cover image generation
+          # Focus on visual representation of the digest type
+          prompt = f"""Create a modern, minimalist cover image for an Armbian {label.lower()}.
+
+          Style guidelines:
+          - Clean, tech-focused aesthetic with subtle gradients
+          - Include Armbian branding elements (use blue tones)
+          - Add the text "{label}" in a modern, bold sans-serif font
+          - Include subtle circuit board or motherboard patterns in the background
+          - Aspect ratio: 16:9 (landscape)
+          - Resolution: 2K
+          - Professional software release style
+          - Leave some negative space for potential overlay text
+          """
+
+          # Initialize the client
+          client = genai.Client(api_key=token)
+
+          # Generate the image
+          response = client.models.generate_content(
+              model="gemini-3.1-flash-image-preview",
+              contents=[prompt],
+              config=types.GenerateContentConfig(
+                  response_modalities=['IMAGE'],
+                  image_config=types.ImageConfig(
+                      aspect_ratio="16:9",
+                      image_size="2K"
+                  )
+              )
+          )
+
+          # Save the generated image
+          for part in response.parts:
+              if hasattr(part, 'inline_data') and part.inline_data is not None:
+                  image = part.as_image()
+                  image.save("cover.png")
+                  print("Cover image generated successfully: cover.png")
+                  break
+          else:
+              print("No image generated - this may indicate an API error")
+          PY
+
       - uses: ncipollo/release-action@v1
         if: ${{ env.RELEASE_ENABLED == 'true' }}
         with:
@@ -256,6 +324,7 @@ jobs:
           prerelease: "false"
           makeLatest: "true"
           bodyFile: "summary.md"
+          artifacts: "cover.png"
           allowUpdates: "true"
           skipIfReleaseExists: "true"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -395,51 +395,6 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Add cover image to workflow summary
-        if: steps.check_cover.outputs.exists == 'true'
-        run: |
-          # Get absolute path for the image
-          IMAGE_PATH="${GITHUB_WORKSPACE}/cover.png"
-
-          # Verify image exists and get its size
-          if [ -f "$IMAGE_PATH" ]; then
-            IMAGE_SIZE=$(ls -lh "$IMAGE_PATH" | awk '{print $5}')
-            ARTIFACTS_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts"
-
-            # Add to workflow summary
-            {
-              echo "## 🎨 Generated Cover Image"
-              echo ""
-              echo "### 📥 Download & View"
-              echo ""
-              echo "🔽 **Download**: [cover.png](../../artifacts) (available in workflow artifacts)"
-              echo ""
-              echo "📦 **All artifacts**: [View artifacts](${ARTIFACTS_URL})"
-              echo ""
-              echo "### 📊 Image Details"
-              echo ""
-              echo "| Property | Value |"
-              echo "|----------|-------|"
-              echo "| **File** | cover.png |"
-              echo "| **Size** | ${IMAGE_SIZE} |"
-              echo "| **Model** | Gemini 3.1 Flash Image Preview |"
-              echo "| **Resolution** | 3168×1344 (2K, 21:9 ultrawide) |"
-              echo "| **Release Attachment** | ✅ Yes |"
-              echo ""
-              echo "<details>"
-              echo "<summary>Technical information</summary>"
-              echo ""
-              echo "- **Workspace path**: \`${IMAGE_PATH}\`"
-              echo "- **Artifact name**: \`cover-image\`"
-              echo "- **Workflow run**: \`${GITHUB_RUN_ID}\`"
-              echo ""
-              echo "</details>"
-              echo ""
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "❌ Cover image not found at ${IMAGE_PATH}" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - uses: ncipollo/release-action@v1
         if: ${{ env.RELEASE_ENABLED == 'true' }}
         with:

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -443,6 +443,21 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: "Prepend cover image to release notes"
+        if: ${{ steps.check_cover.outputs.exists == 'true' && env.RELEASE_ENABLED == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # URL is deterministic: ncipollo uploads cover.png to the same release
+          # in the same step, so the link resolves as soon as the release is live.
+          IMAGE_URL="https://github.com/armbian/build/releases/download/v${VERSION_OVERRIDE}/cover.png"
+          {
+            echo "![${LABEL}](${IMAGE_URL})"
+            echo ""
+            cat summary.md
+          } > summary.md.new
+          mv summary.md.new summary.md
+
       - uses: ncipollo/release-action@v1
         if: ${{ env.RELEASE_ENABLED == 'true' }}
         with:

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -293,9 +293,51 @@ jobs:
           # Determine digest type for title
           digest_title = "Armbian Weekly" if "weekly" in label.lower() else "Armbian Monthly"
 
+          # Generate variation seed based on date to ensure unique images
+          import hashlib
+          date_seed = int(hashlib.md5(current_date.encode()).hexdigest(), 16) % 1000
+
+          # Rotating visual themes for variety (cycles weekly)
+          visual_themes = [
+              "abstract circuit traces with glowing data flow",
+              "layered silicon wafers with kernel rings",
+              "geometric data streams in wave patterns",
+              "hexagonal chip architecture floating in space",
+              "branching code trees with syntax-highlighted nodes",
+              "interconnected server nodes with network topology",
+              "floating motherboard components in zero gravity",
+              "cylindrical data columns with holographic interfaces"
+          ]
+          theme_index = date_seed % len(visual_themes)
+          selected_theme = visual_themes[theme_index]
+
+          # Rotating composition styles
+          composition_styles = [
+              "center-weighted with symmetrical balance",
+              "left-weighted with diagonal leading lines",
+              "right-weighted with S-curve flow",
+              "cinematic rule-of-thirds placement"
+          ]
+          composition_index = (date_seed // 8) % len(composition_styles)
+          selected_composition = composition_styles[composition_index]
+
+          # Rotating lighting moods
+          lighting_moods = [
+              "soft rim lighting from top-left",
+              "dramatic side lighting with strong contrasts",
+              "even ambient glow with subtle highlights",
+              "backlit with forward glow emanating from center"
+          ]
+          lighting_index = (date_seed // 32) % len(lighting_moods)
+          selected_lighting = lighting_moods[lighting_index]
+
           # Dynamic content focus based on PR themes
-          content_focus = """embedded Linux ecosystem, single-board computing, kernel development,
-          system infrastructure, and community-driven innovation"""
+          content_focus = f"""embedded Linux ecosystem, single-board computing, kernel development,
+          system infrastructure, and community-driven innovation.
+
+          UNIQUE ELEMENT FOR THIS WEEK:
+          {selected_theme} as the primary visual anchor, {selected_composition},
+          with {selected_lighting}."""
 
           # Create a high-end, professional prompt
           prompt = f"""Create a high-end, modern tech illustration in a consistent visual identity for {digest_title}.
@@ -307,6 +349,7 @@ jobs:
           - subtle glow, cinematic lighting
           - isometric / semi-3D composition
           - extremely clean, no clutter
+          - UNIQUE VARIATION: Each week features different arrangement of brand elements
 
           BRANDING:
           - inspired by embedded Linux, SBC boards, infrastructure
@@ -324,15 +367,16 @@ jobs:
 
           COMPOSITION:
           - ultrawide cinematic format (21:9 aspect ratio)
-          - left or center weighted
-          - strong focal object (board / chip / abstract system)
+          - {selected_composition}
+          - strong focal object featuring {selected_theme}
+          - {selected_lighting}
           - expansive negative space for text overlay
           - panoramic, sweeping composition
 
           QUALITY:
           - ultra sharp, production-ready marketing image
           - correct typography (no broken text)
-          - consistent style across all outputs
+          - consistent style across all outputs but with unique weekly variations
           """
 
           # Initialize the client

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -250,6 +250,8 @@ jobs:
 
       - name: "Generate AI cover image"
         if: ${{ env.PERIOD == 'weekly' || env.PERIOD == 'monthly' }}
+        timeout-minutes: 5
+        continue-on-error: true
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
@@ -379,8 +381,12 @@ jobs:
           - consistent style across all outputs but with unique weekly variations
           """
 
-          # Initialize the client
-          client = genai.Client(api_key=token)
+          # Initialize the client with a 90s HTTP timeout so a slow/hung
+          # API call surfaces as a clean exception instead of stalling the job.
+          client = genai.Client(
+              api_key=token,
+              http_options=types.HttpOptions(timeout=90_000),
+          )
 
           try:
               # Generate the image
@@ -404,19 +410,19 @@ jobs:
                       print("Cover image generated successfully: cover.png")
                       break
               else:
-                  print("No image generated - this may indicate an API error")
+                  print("::warning title=Cover image::No image returned by Gemini (API may have rejected the prompt)")
                   sys.exit(0)
 
           except ClientError as e:
               if e.status_code == 429:
-                  print("Image generation skipped: Gemini image model requires paid tier (free tier quota exceeded)")
-                  print("To enable: https://ai.google.dev/gemini-api/docs/pricing")
+                  print("::warning title=Cover image::Skipped — Gemini image model requires paid tier (free tier quota exceeded). See https://ai.google.dev/gemini-api/docs/pricing")
                   sys.exit(0)
               else:
-                  print(f"API error: {e}")
+                  print(f"::warning title=Cover image::Gemini API error: {e}")
                   sys.exit(0)
           except Exception as e:
-              print(f"Image generation failed: {e}")
+              # Includes httpx.ReadTimeout / TimeoutError from the 90s SDK timeout above.
+              print(f"::warning title=Cover image::Generation failed or timed out: {e}")
               sys.exit(0)
           PY
 

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -285,10 +285,8 @@ jobs:
           # Extract tagline based on content
           import re
           pr_count = len(re.findall(r'^\*', summary_content, re.MULTILINE))
-          if pr_count > 20:
-              tagline = f"{pr_count} contributions • Community driven"
-          elif pr_count > 10:
-              tagline = f"{pr_count} updates • Open source"
+          if pr_count > 1:
+              tagline = f"{pr_count} Pull Requests Merged"
           else:
               tagline = "Building the future"
 

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -189,7 +189,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${PERIOD:-weekly}" == "monthly" || "${PERIOD:-weekly}" == "quarterly" ]]; then
+          if [[ "$PERIOD" == "monthly" || "$PERIOD" == "quarterly" ]]; then
             FILE="os/stable.json"
           else
             FILE="os/nightly.json"


### PR DESCRIPTION
## Summary

This PR adds AI-powered cover image generation for weekly/monthly digests using Gemini Flash Image, plus a small refactor of the period-based version-file selection in the release summary workflow.

## Changes

### Workflow refactor

- **Simplify `PERIOD` check** for nightly-vs-stable file selection (`${PERIOD:-weekly}` → `$PERIOD`). The old form was functionally equivalent given that `PERIOD` is always set as a job-level env, but the new form is clearer and consistent with the rest of the script.

### AI cover image generation (new feature)

<img width="3168" height="1344" alt="cover" src="https://github.com/user-attachments/assets/bfef28c2-f1e6-4ac6-95cf-1d3b5817c4e3" />

- Automated cover image generation using **Gemini 3.1 Flash Image Preview** (Nano Banana 2)
- **21:9 ultrawide cinematic** images at **3168×1344 (2K)** resolution
- Visual identity:
  - Premium, minimalistic, futuristic aesthetic
  - Navy/deep blue gradients with orange accents (Armbian brand)
  - Abstract circuits, silicon, data flow patterns
  - Dynamic titles ("Armbian Weekly" / "Armbian Monthly")
  - Current date subtitle (e.g., "April 30, 2026")
  - Tagline based on PR count ("205 Pull Requests Merged")
  - Panoramic, sweeping compositions
- **Deterministic weekly variation**: date-seeded rotation across 8 visual themes × 4 compositions × 4 lighting moods so consecutive weeks differ while overall identity stays consistent.

### Reliability hardening (latest commits)

- **90s SDK-level HTTP timeout** on the Gemini call so a slow or hung API request fails cleanly instead of stalling the runner. (Motivated by a real 29-minute hang seen on a manual run today.)
- **5-minute step-level `timeout-minutes` backstop** in case the Python process itself wedges before the SDK timeout fires.
- **`continue-on-error: true`** so release publishing proceeds whether or not the cover image succeeds.
- **`::warning::` annotations** on every skip/fail path (no API key, 429 quota, generic API error, generic exception, no image returned) so failures show up on the run summary instead of being silent.

### Pricing & requirements

- **Paid tier required**: Gemini 3.1 Flash Image Preview is not available on the free tier (image quota: 0).
- Requires a paid-tier API key from [Google AI Studio](https://aistudio.google.com/app/apikey).
- Workflow degrades gracefully (warning + skip, no failure) when:
  - `GEMINI_API_KEY` secret is not configured
  - A free-tier key is used (catches 429)
  - The API errors out or times out

### Deliverables

The generated cover image is:

- Created as `cover.png` (21:9, 3168×1344, PNG)
- Uploaded as workflow artifact `cover-image`
- Attached to the GitHub release on `armbian/build`

## Setup

To enable image generation, add a GitHub secret:

- **Name**: `GEMINI_API_KEY`
- **Value**: from [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
- **Requirement**: paid-tier API key

Without the secret (or on free tier), the workflow runs to completion and emits a warning instead of generating an image.

## Commits

1. `1e5b59f` — fix: correct PERIOD condition in release summary workflow
2. `d8090e7` — feat: add AI cover image generation with Gemini Flash Image
3. `fdd86f6` — refactor: improve AI image prompt with professional branding spec
4. `0d22b7b` — fix: handle free tier quota error in image generation
5. `249bcce` — feat: display generated cover image in workflow summary
6. `00da6c8` — fix: properly display cover image in workflow summary
7. `7ba8b56` — feat: change cover image aspect ratio to 21:9 ultrawide
8. `f95b928` — chore: remove cover image from workflow summary
9. `20441d5` — refactor: simplify tagline to show PR count
10. `8cbbaf2` — feat: add dynamic variations for unique weekly images
11. `4600ce3` — fix: add timeout and warnings to cover image generation

## Test plan

- [x] Verify version file selection (nightly.json vs stable.json) for each `PERIOD`
- [x] Generate image successfully with paid-tier API key (verified on a prior manual run)
- [x] Verify graceful skip / 429 path with free-tier API key
- [x] Verify image is uploaded as artifact and attached to release
- [ ] Verify the new 90s SDK timeout fires as a `::warning::` (replaying the 29-min hang scenario; pending next manual run)
- [ ] Verify the 5-minute step-level backstop does not fire under normal generation (~10–30s typical)

## Technical details

**Image specifications**

- Model: `gemini-3.1-flash-image-preview` (Nano Banana 2)
- Aspect ratio: 21:9 (ultrawide cinematic)
- Resolution: 3168×1344 (2K)
- Format: PNG

**Prompt engineering**

- Context-aware based on digest type (weekly vs. monthly)
- PR-count-driven tagline
- Brand-consistent visual language
- Date-seeded rotation across themes / composition / lighting for weekly variety