### PR TITLE
fix: route forky/loong64 base-files lookups to the main archive

### DIFF
--- a/scripts/generate-base-files-info-json.py
+++ b/scripts/generate-base-files-info-json.py
@@ -177,9 +177,23 @@ def get_debian_binary_package_filename(distro, release_name, package_name, archi
     Path(cache_dir).mkdir(exist_ok=True)
 
     # Build URLs for Packages file
+    #
+    # Per-release set of architectures that, *for this release*, live
+    # only in debian-ports/ rather than the main archive. loong64 was
+    # promoted to the main archive in forky and stays in debian-ports
+    # for sid; bookworm/trixie don't list loong64 at all so they never
+    # reach this branch via get_debian_architectures.
+    #
+    # When a future arch goes through the same promotion cycle, add it
+    # here per-release; when sid promotes loong64 to main, drop the
+    # entry entirely.
+    debian_ports_only = {
+        'sid': {'loong64'},
+    }.get(release_name, set())
+
     match distro:
         case 'debian':
-            if( architecture == 'loong64' ):
+            if architecture in debian_ports_only:
                 base_url = "http://ftp.ports.debian.org/debian-ports/"
             else:
                 base_url = "http://ftp.debian.org/debian/"


### PR DESCRIPTION
## Summary

The scheduled \`Data: Generate base-files package index\` workflow ([run 25245214054](https://github.com/armbian/armbian.github.io/actions/runs/25245214054)) is failing with:

\`\`\`
Downloading Packages.gz for forky (loong64)...
requests.exceptions.HTTPError: 404 Client Error: Not Found for url:
http://ftp.ports.debian.org/debian-ports//dists/forky/main/binary-loong64/Packages.gz
\`\`\`

## Root cause

\`generate-base-files-info-json.py\` had an unconditional rule: any \`loong64\` lookup goes to \`ftp.ports.debian.org/debian-ports/\`. That was correct when loong64 was strictly a port — but in **forky**'s testing cycle loong64 graduated to the **main** Debian archive. forky's \`InRelease\` now lists it under \`Architectures:\`, so the architecture loop hits it, and the hard-coded debian-ports URL 404s because that path doesn't exist.

\`sid\` still hosts loong64 as a port (sid's main \`InRelease\` doesn't list it, which is why \`architectures += ['loong64']\` is added manually for sid at the call site), so we can't just remove the debian-ports branch — we still need it for sid.

## Fix

Replace the global \`architecture == 'loong64'\` switch with a per-release set of "ports-only" architectures. Today only \`sid + loong64\` is in the bucket; forky and later get the main archive.

\`\`\`python
debian_ports_only = {
    'sid': {'loong64'},
}.get(release_name, set())

if architecture in debian_ports_only:
    base_url = "http://ftp.ports.debian.org/debian-ports/"
else:
    base_url = "http://ftp.debian.org/debian/"
\`\`\`

When sid finally promotes loong64 to main, drop the dict entry; when a future arch goes through the same promotion cycle, add it here per-release.

## Test plan

- [x] Re-run the failed cron (workflow_dispatch on \`Data: Generate base-files package index\`) — should complete and commit \`base-files.json\` with forky/loong64 populated from the main archive.
- [ ] Output JSON includes \`forky.loong64\` with a base-files filename present at \`http://ftp.debian.org/debian/dists/forky/main/binary-loong64/Packages.gz\`.
- [ ] sid/loong64 entry continues to come from \`debian-ports\` (sanity check the dict-driven fallback still fires for sid).