### PR TITLE
release-targets: drop mesa-vpu from auto-attached extensions

### DIFF
--- a/release-targets/README.md
+++ b/release-targets/README.md
@@ -54,7 +54,7 @@ The exact codename each `RELEASE:` line resolves to depends on which `--<distro>
 
 ### By performance / arch (driven by `KERNEL_SRC_ARCH` and `BOARD_HAS_VIDEO`)
 
-- **Fast HDMI** — `arm64`, `x86` boards with video. Get `gnome_desktop` recommendation, automatic `mesa-vpu` + `v4l2loopback-dkms` extensions.
+- **Fast HDMI** — `arm64`, `x86` boards with video. Get `gnome_desktop` recommendation, automatic `v4l2loopback-dkms` extension.
 - **Slow HDMI** — `arm` (32-bit) boards with video. Get `xfce_desktop` recommendation.
 - **Headless** — `BOARD_HAS_VIDEO: false`. Get `minimal` (CLI) recommendation.
 - **RISC-V** — `riscv64`. Separate category, single XFCE desktop pattern (with the SpacemiT K1 family overridden to Bianbu via `exposed.map.overrides.yaml`).
@@ -78,15 +78,15 @@ rock-5b:current::ENABLE_EXTENSIONS="custom-extension"
 nanopi-r4s:::ENABLE_EXTENSIONS="test-extension"
 ```
 
-Manual entries are **merged** with the automatic fast-HDMI extensions (`mesa-vpu`, `v4l2loopback-dkms`).
+Manual entries are **merged** with the automatic fast-HDMI extension (`v4l2loopback-dkms`).
 
 ### `targets-extensions.map.blacklist`
 
 ```ini
 # Format: BOARD:branch1:branch2:...:REMOVE_EXTENSIONS="ext1,ext2"
 
-radxa-e54c:::REMOVE_EXTENSIONS="v4l2loopback-dkms,mesa-vpu"
-uefi-x86:current::REMOVE_EXTENSIONS="mesa-vpu"
+radxa-e54c:::REMOVE_EXTENSIONS="v4l2loopback-dkms"
+uefi-x86:current::REMOVE_EXTENSIONS="v4l2loopback-dkms"
 ```
 
 The blacklist takes precedence over both automatic and manual extensions.
@@ -195,7 +195,6 @@ The same per-scope codenames also drive the regex patterns in `exposed.map`, so 
 All fast-HDMI boards (64-bit boards with video output) automatically get:
 
 - `v4l2loopback-dkms`
-- `mesa-vpu`
 
 Manual entries from `targets-extensions.map` are merged with these; entries in `targets-extensions.map.blacklist` are removed from both automatic and manual sets. The blacklist wins.
 

--- a/release-targets/targets-extensions.map
+++ b/release-targets/targets-extensions.map
@@ -2,7 +2,7 @@
 # Format: BOARD_NAME:branch1:branch2:...:ENABLE_EXTENSIONS="extension1,extension2"
 
 # Example 1: Board with automatic RK35* extensions getting additional manual extension
-# 9tripod-x3568-v4 has RK3568, so it gets v4l2loopback-dkms,mesa-vpu automatically
+# 9tripod-x3568-v4 has RK3568, so it gets v4l2loopback-dkms automatically
 # We add image-output-oowow manually
 # 9tripod-x3568-v4:current::ENABLE_EXTENSIONS="image-output-oowow"
 # Example 2: Board without automatic extensions, adding manual extensions
@@ -16,5 +16,5 @@ khadas-vim3:::ENABLE_EXTENSIONS="image-output-oowow"
 khadas-vim3l:::ENABLE_EXTENSIONS="image-output-oowow"
 khadas-vim4:::ENABLE_EXTENSIONS="image-output-oowow"
 uefi-x86:::ENABLE_EXTENSIONS="nvidia"
-musepipro:::ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu"
-bananapif3:::ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu"
+musepipro:::ENABLE_EXTENSIONS: "v4l2loopback-dkms"
+bananapif3:::ENABLE_EXTENSIONS: "v4l2loopback-dkms"

--- a/release-targets/targets-extensions.map.blacklist
+++ b/release-targets/targets-extensions.map.blacklist
@@ -1,7 +1,7 @@
 # Extensions Blacklist
 # ------------------
 # This file defines extensions that should be REMOVED from specific boards,
-# overriding the auto-added extensions (like v4l2loopback-dkms, mesa-vpu for fast HDMI boards).
+# overriding the auto-added extensions (e.g. v4l2loopback-dkms for fast HDMI boards).
 #
 # Format: BOARD_NAME:branch1:branch2:...:REMOVE_EXTENSIONS="ext1,ext2"
 #
@@ -11,9 +11,9 @@
 # - REMOVE_EXTENSIONS: comma-separated list of extensions to remove
 #
 # Examples:
-#   boardx:::REMOVE_EXTENSIONS="mesa-vpu"           # Remove mesa-vpu from all branches
-#   boardy:current::REMOVE_EXTENSIONS="mesa-vpu"     # Remove only from current branch
-#   boardz::vendor:edge:REMOVE_EXTENSIONS="ext1"     # Remove from vendor and edge only
+#   boardx:::REMOVE_EXTENSIONS="v4l2loopback-dkms"          # Remove from all branches
+#   boardy:current::REMOVE_EXTENSIONS="v4l2loopback-dkms"   # Remove only from current branch
+#   boardz::vendor:edge:REMOVE_EXTENSIONS="ext1"            # Remove from vendor and edge only
 #
 # Boards listed below:
-radxa-e54c:::REMOVE_EXTENSIONS="v4l2loopback-dkms,mesa-vpu"
+radxa-e54c:::REMOVE_EXTENSIONS="v4l2loopback-dkms"

--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -59,8 +59,8 @@ desktop-stable-ubuntu-gnome-uefi:
     DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
-    - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
-    - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu,nvidia" }
+    - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
     - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
@@ -81,8 +81,8 @@ desktop-stable-ubuntu-cinnamon-uefi:
     DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
-    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
-    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu,nvidia" }
+    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
     - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }

--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -492,8 +492,8 @@ def is_fast_hardware(entry):
 
 def get_soc_extensions(entry, extensions_map=None, remove_extensions_map=None):
     """
-    Determine if board needs v4l2loopback-dkms and mesa-vpu extensions.
-    For fast HDMI boards, automatically adds these extensions.
+    Determine which build extensions a board needs.
+    For fast HDMI boards, automatically adds v4l2loopback-dkms.
     Also merges manual extensions from the extensions map.
     Removes extensions specified in remove_extensions_map.
     Returns a comma-separated string of extensions or empty string.
@@ -505,10 +505,12 @@ def get_soc_extensions(entry, extensions_map=None, remove_extensions_map=None):
 
     extensions = []
 
-    # Add automatic extensions for all fast HDMI boards
+    # Add automatic extensions for all fast HDMI boards.
+    # mesa-vpu used to live here too; it was retired when its
+    # responsibilities moved to armbian-config's module_desktops
+    # (armbian/build PR #9683 deletes the extension itself).
     if is_fast_hardware(entry) is True:
         extensions.append('v4l2loopback-dkms')
-        extensions.append('mesa-vpu')
 
     # Then, add manual extensions (merges with automatic ones)
     if extensions_map:


### PR DESCRIPTION
## Summary

Strip every reference to the `mesa-vpu` extension from `release-targets/`. Companion to [armbian/build#9683](https://github.com/armbian/build/pull/9683), which retires the extension itself.

## Why now

[armbian/os run 25282829640, job 74125272015](https://github.com/armbian/os/actions/runs/25282829640/job/74125272015) — `rootfs-arm64-trixie-minimal` failed with:

```
ERR: Extension problem -- cant find extension 'mesa-vpu' anywhere
ERROR: Exiting with error 17 at lib/functions/general/extensions.sh:1
```

Once #9683 lands on `armbian/build`'s main, every fast-HDMI matrix slot still passing `ENABLE_EXTENSIONS=...mesa-vpu...` will fail this way. This PR cleans up the matrix-emitting side so the merge doesn't break nightly.

## What changes

| File | Lines | What |
|---|---|---|
| `scripts/generate_targets.py` | `get_soc_extensions` | drop `mesa-vpu` from the fast-HDMI auto-attach list; keep `v4l2loopback-dkms` |
| `targets-release-standard-support.manual` | gnome/cinnamon × current/edge × uefi-arm64/uefi-x86 (4 lines) | strip `,mesa-vpu` from explicit `ENABLE_EXTENSIONS` |
| `targets-extensions.map` | musepipro, bananapif3 | strip `,mesa-vpu` from the RISC-V K1 entries (where mesa-vpu never made sense — K1 is PowerVR, not a Rockchip VPU) |
| `targets-extensions.map.blacklist` | radxa-e54c | shrink REMOVE list to just `v4l2loopback-dkms` (mesa-vpu isn't being added in the first place anymore) |
| `README.md` | "Automatic extensions", "Fast HDMI", examples | doc updates |

`v4l2loopback-dkms` is left alone — it's a separate extension, still owned by `armbian/build`. The user's scope was specifically mesa-vpu.

A comment in `generate_targets.py` records why mesa-vpu was removed so the next maintainer reading the function doesn't re-add it without checking the configng companion work.

## Behaviour after merge

- `release-targets/*.yaml` regenerates with no `,mesa-vpu` in any `ENABLE_EXTENSIONS` string.
- `armbian/os` ingests the new YAML on its next regen.
- `rootfs-arm64-trixie-minimal` (and every other slot that was breaking on this) goes green again on the next nightly.
- v4l2loopback-dkms continues to attach to fast-HDMI boards as before.

## Test plan

- [ ] After merge: trigger `Infrastructure: APT repositories update` (or equivalent regen path); confirm `release-targets/targets-release-*.yaml` no longer contains `mesa-vpu`.
- [ ] After both this PR and #9683 land: trigger an `armbian/os` nightly and confirm fast-HDMI slots build (rootfs + image) with no `Extension problem` errors.
- [ ] Spot-check `radxa-e54c`: confirm v4l2loopback-dkms is still being removed for that board (the REMOVE list now lists only that one extension).