### PR TITLE
release-targets: switch fast-HDMI KDE matrix from kde-neon to kde-plasma

### DIFF
--- a/scripts/generate-rpi-imager-json.py
+++ b/scripts/generate-rpi-imager-json.py
@@ -50,7 +50,8 @@ class RpiImagerGenerator:
         "gnome": "Gnome Desktop",
         "minimal": "Minimal",
         "xfce": "Xfce Desktop",
-        "kde-neon": "KDE Neon Desktop",
+        "kde-neon": "KDE Neon Desktop",      # legacy — kept for images still on the mirror
+        "kde-plasma": "KDE Plasma Desktop",
         "cinnamon": "Cinnamon Desktop",
         "mate": "Mate Desktop",
         "i3-wm": "I3 Window Manager",

--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -1166,11 +1166,17 @@ targets:
         if edge_fast:
             yaml += '      - *stable-edge-fast-hdmi\n'
 
-    # Ubuntu stable KDE Neon desktop (fast HDMI only)
+    # Ubuntu stable KDE Plasma desktop (fast HDMI only).
+    # Was kde-neon; switched to kde-plasma when the standard scope
+    # promoted to resolute — KDE Neon is pinned to a specific Ubuntu
+    # LTS (currently noble) and doesn't have a resolute build, while
+    # kde-plasma tracks the distro and works on every release we
+    # ship to (configng kde-plasma.yaml advertises arm64+amd64 from
+    # bookworm through resolute).
     if current_fast or edge_fast:
         yaml += """
-  # Ubuntu stable KDE Neon desktop (fast HDMI only)
-  desktop-stable-ubuntu-kde-neon:
+  # Ubuntu stable KDE Plasma desktop (fast HDMI only)
+  desktop-stable-ubuntu-kde-plasma:
     enabled: yes
     configs: [ armbian-images ]
     pipeline:
@@ -1180,7 +1186,7 @@ targets:
       RELEASE: UBUNTU
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
-      DESKTOP_ENVIRONMENT: "kde-neon"
+      DESKTOP_ENVIRONMENT: "kde-plasma"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: "programming"
       DESKTOP_TIER: "mid"
@@ -1724,11 +1730,14 @@ targets:
     if edge_fast:
         yaml += '      - *community-edge-fast-hdmi\n'
 
-    # Ubuntu KDE Neon desktop for fast HDMI community boards
+    # Ubuntu KDE Plasma desktop for fast HDMI community boards.
+    # Was kde-neon; same reason as the standard-support block above —
+    # kde-neon is pinned to a specific Ubuntu LTS and the community
+    # scope tracks resolute now.
     if current_fast or vendor_fast or edge_fast:
         yaml += """
-  # Ubuntu KDE Neon desktop for fast HDMI community boards
-  community-noble-kde-neon:
+  # Ubuntu KDE Plasma desktop for fast HDMI community boards
+  community-noble-kde-plasma:
     enabled: yes
     configs: [ armbian-community ]
     pipeline:
@@ -1738,7 +1747,7 @@ targets:
       RELEASE: UBUNTU
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
-      DESKTOP_ENVIRONMENT: "kde-neon"
+      DESKTOP_ENVIRONMENT: "kde-plasma"
       DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
       DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"


### PR DESCRIPTION
## Symptom

Both KDE matrix blocks emit with `RELEASE: UBUNTU`, which substitutes to whatever `--ubuntu-<scope>` codename is active. After the noble→resolute promotion of `--ubuntu-standard` and `--ubuntu-community`, both KDE Neon blocks resolve to `RELEASE: resolute` — and KDE Neon is pinned to a specific Ubuntu LTS (currently noble), with no resolute build. The image build can't find KDE Neon packages and fails.

## Fix

Switch both blocks to `kde-plasma`. configng's [`kde-plasma.yaml`](https://github.com/armbian/configng/blob/main/tools/modules/desktops/yaml/kde-plasma.yaml) advertises `arm64 + amd64` from bookworm through resolute, so the same emit covers every codename in the fleet without needing per-release carve-outs.

| Before | After |
|---|---|
| `desktop-stable-ubuntu-kde-neon` | `desktop-stable-ubuntu-kde-plasma` |
| `community-noble-kde-neon` | `community-noble-kde-plasma` |
| `DESKTOP_ENVIRONMENT: "kde-neon"` (×2) | `DESKTOP_ENVIRONMENT: "kde-plasma"` (×2) |

## rpi-imager mapping

Added `"kde-plasma": "KDE Plasma Desktop"` to `generate-rpi-imager-json.py`'s display-name dict. Kept the `kde-neon` row — any straggler kde-neon images still on the mirror keep their pretty label until they age out of the published set.

## Inline comments

Both emit blocks now carry a short note explaining *why* kde-neon was retired (release-pin issue) so the next maintainer doesn't add it back without first checking whether kde-neon has caught up to the current `ubuntu-<scope>` default.

## Test plan

- [x] After merge, regenerate `release-targets/targets-release-*.yaml` and confirm `kde-neon` is gone from the matrix output (only `kde-plasma` blocks remain).
- [x] Trigger an `armbian/os` build of `desktop-stable-ubuntu-kde-plasma` against a fast-HDMI board and confirm the rootfs assembles + image builds.
- [x] Confirm the rpi-imager JSON shows "KDE Plasma Desktop" for any new image whose filename contains `_kde-plasma_`.