### PR TITLE
release-targets/standard-support.manual: add UEFI desktops + plain cloud

### DIFF
--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -45,6 +45,27 @@ minimal-stable-ubuntu-current-uefi:
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
+# Ubuntu minimal with current kernel - UEFI only - noble (LTS)
+minimal-stable-ubuntu-noble-current-uefi:
+  enabled: yes
+  configs: [ armbian-images ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: noble
+    BUILD_MINIMAL: "yes"
+    BUILD_DESKTOP: "no"
+  items:
+    - { BOARD: uefi-arm64, BRANCH: current }
+    - { BOARD: uefi-x86, BRANCH: current }
+    - { BOARD: uefi-arm64, BRANCH: cloud }
+    - { BOARD: uefi-x86, BRANCH: cloud }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
+
 # Ubuntu GNOME desktop - UEFI only
 desktop-stable-ubuntu-gnome-uefi:
   enabled: yes

--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -36,6 +36,8 @@ minimal-stable-ubuntu-current-uefi:
   items:
     - { BOARD: uefi-arm64, BRANCH: current }
     - { BOARD: uefi-x86, BRANCH: current }
+    - { BOARD: uefi-arm64, BRANCH: cloud }
+    - { BOARD: uefi-x86, BRANCH: cloud }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -86,3 +88,79 @@ desktop-stable-ubuntu-cinnamon-uefi:
     - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
+
+# Ubuntu KDE Plasma desktop - UEFI only
+desktop-stable-ubuntu-kde-plasma-uefi:
+  enabled: yes
+  configs: [ armbian-images ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: UBUNTU
+    BUILD_MINIMAL: "no"
+    BUILD_DESKTOP: "yes"
+    DESKTOP_ENVIRONMENT: "kde-plasma"
+    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
+    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
+    DESKTOP_TIER: "mid"
+  items:
+    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
+
+# Ubuntu MATE desktop - UEFI only
+desktop-stable-ubuntu-mate-uefi:
+  enabled: yes
+  configs: [ armbian-images ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: UBUNTU
+    BUILD_MINIMAL: "no"
+    BUILD_DESKTOP: "yes"
+    DESKTOP_ENVIRONMENT: "mate"
+    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
+    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
+    DESKTOP_TIER: "mid"
+  items:
+    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
+
+# Ubuntu Xfce desktop - UEFI only
+desktop-stable-ubuntu-xfce-uefi:
+  enabled: yes
+  configs: [ armbian-images ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: UBUNTU
+    BUILD_MINIMAL: "no"
+    BUILD_DESKTOP: "yes"
+    DESKTOP_ENVIRONMENT: "xfce"
+    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
+    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
+    DESKTOP_TIER: "mid"
+  items:
+    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
+
+# Ubuntu i3 window-manager - UEFI only
+desktop-stable-ubuntu-i3-wm-uefi:
+  enabled: yes
+  configs: [ armbian-images ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: UBUNTU
+    BUILD_MINIMAL: "no"
+    BUILD_DESKTOP: "yes"
+    DESKTOP_ENVIRONMENT: "i3-wm"
+    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
+    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
+    DESKTOP_TIER: "mid"
+  items:
+    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }


### PR DESCRIPTION
## Summary
- Add UEFI desktop variants for all `supported` DEs covering both amd64 and arm64 not yet present: kde-plasma, mate, xfce, i3-wm (Ubuntu only, per request).
- Add plain `cloud` kernel entries (no extensions) for both `uefi-arm64` and `uefi-x86` to the existing `minimal-stable-ubuntu-current-uefi` block.
- Each new desktop block follows the same shape as the existing cinnamon/gnome variants: `BRANCH: current` with `v4l2loopback-dkms` (arm64) and `v4l2loopback-dkms,nvidia` (x86).

## Test plan
- [ ] Generated `targets-release-standard-support.yaml` includes the four new desktop targets.
- [ ] Generated cloud entries do not carry `ENABLE_EXTENSIONS`.
- [ ] No regression in existing gnome/cinnamon UEFI desktop builds.