### PR TITLE
reporting-release-summary: prepend 'Armbian' to digest titles

### DIFF
--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Ensure dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq pngquant
+          sudo apt-get install -y jq pngquant imagemagick
 
       - name: Compute time window (UTC) from period
         id: when
@@ -475,18 +475,40 @@ jobs:
               sys.exit(0)
 
           try:
-              # google.genai.types.Image is a raw-bytes wrapper, not a PIL.Image —
-              # only .save(path) is available. Save as PNG (Gemini's native format).
+              # google.genai.types.Image is a raw-bytes wrapper, not a PIL.Image:
+              # .save(path) writes the bytes verbatim, ignoring the extension. So
+              # if Gemini returns JPEG (which it sometimes does even when we ask
+              # for PNG), naming the file cover.png puts JPEG bytes in a PNG-named
+              # file and pngquant rejects it with "Not a PNG file (libpng failed)".
+              #
+              # Inspect the actual mime_type on inline_data and normalise to PNG
+              # via ImageMagick when needed, so cover.png is always a real PNG.
+              import subprocess
               for part in response.parts:
                   if hasattr(part, 'inline_data') and part.inline_data is not None:
+                      mime = (part.inline_data.mime_type or "").lower()
                       image = part.as_image()
-                      image.save("cover.png")
+                      ext_map = {"image/png": "png", "image/jpeg": "jpg", "image/webp": "webp"}
+                      src_ext = ext_map.get(mime)
+                      if src_ext is None:
+                          print(f"::warning title=Cover image::Unsupported mime_type '{mime}' from Gemini; skipping cover")
+                          sys.exit(0)
+                      if src_ext == "png":
+                          image.save("cover.png")
+                      else:
+                          src = f"cover.src.{src_ext}"
+                          image.save(src)
+                          subprocess.run(["convert", src, "cover.png"], check=True)
+                          os.remove(src)
                       size_kb = os.path.getsize("cover.png") // 1024
-                      print(f"Cover image generated successfully: cover.png ({size_kb} KB)")
+                      print(f"Cover image generated successfully: cover.png ({size_kb} KB, source mime={mime})")
                       break
               else:
                   print("::warning title=Cover image::No image returned by Gemini (API may have rejected the prompt)")
                   sys.exit(0)
+          except subprocess.CalledProcessError as e:
+              print(f"::warning title=Cover image::ImageMagick conversion failed: {e}")
+              sys.exit(0)
           except Exception as e:
               print(f"::warning title=Cover image::Failed to encode/save image: {e}")
               sys.exit(0)

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.AI_MODELS }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       SCOPE: ${{ inputs.scope || 'org:armbian' }}
       TZ: ${{ inputs.tz || 'Europe/Ljubljana' }}
       PERIOD: ${{ inputs.period || 'weekly' }}
@@ -54,8 +54,8 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install OpenAI SDK
-        run: pip install 'openai>=1.0.0'
+      - name: Install Anthropic SDK
+        run: pip install 'anthropic>=0.40.0'
 
       - name: Install Google Gen AI SDK
         run: pip install 'google-genai>=1.0.0'
@@ -210,33 +210,70 @@ jobs:
           set -euo pipefail
           python3 <<'PY'
           import os
-          from openai import OpenAI
+          from anthropic import Anthropic
 
-          token = os.environ["GITHUB_TOKEN"]
           label = os.environ["LABEL"]
 
           with open("summary.md", "r", encoding="utf-8") as f:
               content = f.read().strip()
 
-          client = OpenAI(base_url="https://models.github.ai/inference", api_key=token)
+          # Reads ANTHROPIC_API_KEY from the env. claude-opus-4-7 doesn't accept
+          # temperature/top_p/top_k (those 400 on this model). Adaptive thinking
+          # is enabled so Claude plans the thematic structure before drafting —
+          # noticeably better narrative flow than a one-shot completion.
+          client = Anthropic()
+
+          system = (
+              f"You are a professional technical editor writing the {label} for an "
+              "embedded Linux audience.\n\n"
+
+              "Priority:\n"
+              "1) Accuracy and signal over completeness\n"
+              "2) Clear thematic grouping\n"
+              "3) Professional tone\n\n"
+
+              "Voice:\n"
+              "Clear, precise, and business-professional. No slang or casual phrasing. "
+              "Avoid expressive or playful language (e.g., 'glow-up', 'shown the door'). "
+              "Do not use filler openings.\n\n"
+
+              "Style:\n"
+              "Use controlled rhetorical structure for clarity — parallelism and "
+              "rule-of-three phrasing are encouraged. Avoid metaphors and figurative language. "
+              "Use light contrast only where it improves understanding.\n\n"
+
+              "Content selection:\n"
+              "- Group changes into 2–3 dominant themes\n"
+              "- Highlight only the most impactful or representative changes\n"
+              "- Do not enumerate all items\n"
+              "- Prefer architectural, platform, and user-visible changes over minor fixes\n\n"
+
+              "Structure:\n"
+              "- First sentence names the main themes\n"
+              "- Then 2–3 short paragraphs, one per theme\n"
+              "- Each paragraph expands the theme with key examples\n"
+              "- Use **bold phrases (3–6 words)** for emphasis sparingly\n"
+              "- Separate paragraphs with a blank line\n"
+          )
 
           prompt = (
-              "Read the following Markdown changelog and write a short journalistic intro paragraph (5–7 sentences) "
-              "that summarizes the main activity. Be concise, professional, and factual. Output only the intro.\n\n"
+              "Below is a Markdown changelog of merged pull requests.\n\n"
+              "Write a concise professional summary following the system instructions. "
+              "Use 2–3 paragraphs, each covering one theme. End with a single line of "
+              "relevant hashtags after a blank line.\n\n"
+              "Output only the summary and hashtags.\n\n"
               f"{content}"
           )
 
-          resp = client.chat.completions.create(
-              model="openai/gpt-4.1",
-              messages=[
-                  {"role": "system", "content": "You are a " + label + "digest editor."},
-                  {"role": "user", "content": prompt},
-              ],
-              temperature=0.3,
-              top_p=1.0,
+          resp = client.messages.create(
+              model="claude-opus-4-7",
+              max_tokens=4096,
+              thinking={"type": "adaptive"},
+              system=system,
+              messages=[{"role": "user", "content": prompt}],
           )
 
-          intro = resp.choices[0].message.content.strip()
+          intro = next((b.text for b in resp.content if b.type == "text"), "").strip()
 
           with open("summary.md", "w", encoding="utf-8") as f:
               f.write(intro + "\n\n" + content)

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Ensure dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq
+          sudo apt-get install -y jq pngquant
 
       - name: Compute time window (UTC) from period
         id: when
@@ -287,7 +287,8 @@ jobs:
 
       - name: "Generate AI cover image"
         if: ${{ env.PERIOD == 'weekly' || env.PERIOD == 'monthly' }}
-        timeout-minutes: 5
+        # 10m ceiling = headroom for 2x 240s SDK timeout + 30s retry wait + buffer.
+        timeout-minutes: 10
         continue-on-error: true
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -329,8 +330,9 @@ jobs:
           else:
               tagline = "Building the future"
 
-          # Determine digest type for title
-          digest_title = "Armbian Weekly" if "weekly" in label.lower() else "Armbian Monthly"
+          # Use the LABEL verbatim ("Armbian Weekly digest", "Armbian Monthly digest")
+          # so the image title matches the release name.
+          digest_title = label
 
           # Generate variation seed based on date to ensure unique images
           import hashlib
@@ -351,11 +353,12 @@ jobs:
           selected_theme = visual_themes[theme_index]
 
           # Rotating composition styles
+          # Compositions push the focal object off-center so the title can
+          # render as a single uninterrupted block in the opposite half.
           composition_styles = [
-              "center-weighted with symmetrical balance",
-              "left-weighted with diagonal leading lines",
-              "right-weighted with S-curve flow",
-              "cinematic rule-of-thirds placement"
+              "left-weighted with diagonal leading lines, focal object in the left third",
+              "right-weighted with S-curve flow, focal object in the right third",
+              "cinematic rule-of-thirds placement, focal object off-center",
           ]
           composition_index = (date_seed // 8) % len(composition_styles)
           selected_composition = composition_styles[composition_index]
@@ -400,9 +403,13 @@ jobs:
           {content_focus}
 
           TEXT IN IMAGE:
-          - title: "{digest_title}"
-          - subtitle: "{current_date}"
-          - optional small caption: "{tagline}"
+          - title: "{digest_title}" — LARGE bold typography occupying ~14% of frame height, dominant in the layout
+          - subtitle: "{current_date}" — supporting text at ~6% of frame height, clearly readable
+          - optional small caption: "{tagline}" — supporting text at ~4% of frame height
+          - the title is a SINGLE CONTINUOUS BLOCK — one line, or stacked lines as a unit; never split or interrupted by graphics
+          - text and the visual theme occupy DISTINCT zones of the frame; do not place focal objects between title words
+          - all text must be highly readable at thumbnail size; treat typography as the second focal element after the visual theme
+          - high contrast against background; no thin or condensed typefaces
 
           COMPOSITION:
           - ultrawide cinematic format (21:9 aspect ratio)
@@ -418,50 +425,85 @@ jobs:
           - consistent style across all outputs but with unique weekly variations
           """
 
-          # Initialize the client with a 90s HTTP timeout so a slow/hung
-          # API call surfaces as a clean exception instead of stalling the job.
+          # 4 min HTTP timeout — Gemini 3.1 Flash Image Preview routinely takes
+          # 60-180 s for 21:9 / 1K with our detailed prompt. Step ceiling is 8m
+          # (above), so the SDK fails first with a useful message instead of the
+          # runner killing the step.
           client = genai.Client(
               api_key=token,
-              http_options=types.HttpOptions(timeout=90_000),
+              http_options=types.HttpOptions(timeout=240_000),
           )
 
-          try:
-              # Generate the image
-              response = client.models.generate_content(
-                  model="gemini-3.1-flash-image-preview",
-                  contents=[prompt],
-                  config=types.GenerateContentConfig(
-                      response_modalities=['IMAGE'],
-                      image_config=types.ImageConfig(
-                          aspect_ratio="21:9",
-                          image_size="1K"
+          # Retry up to 2 times on transient errors (504 DEADLINE_EXCEEDED,
+          # 503 UNAVAILABLE, network blips). 429 quota and other 4xx are NOT
+          # retried — they won't succeed on a second try.
+          import time
+          response = None
+          last_err = None
+          for attempt in range(1, 3):
+              if attempt > 1:
+                  wait = 30
+                  print(f"::warning title=Cover image::Attempt {attempt - 1} failed ({last_err}); retrying in {wait}s")
+                  time.sleep(wait)
+              try:
+                  response = client.models.generate_content(
+                      model="gemini-3.1-flash-image-preview",
+                      contents=[prompt],
+                      config=types.GenerateContentConfig(
+                          response_modalities=['IMAGE'],
+                          image_config=types.ImageConfig(
+                              aspect_ratio="21:9",
+                              image_size="1K"
+                          )
                       )
                   )
-              )
+                  break
+              except ClientError as e:
+                  if e.status_code == 429:
+                      print("::warning title=Cover image::Skipped — Gemini image model requires paid tier (free tier quota exceeded). See https://ai.google.dev/gemini-api/docs/pricing")
+                      sys.exit(0)
+                  # Other 4xx (400 invalid prompt, 401 auth, 403 forbidden) — don't retry.
+                  print(f"::warning title=Cover image::Gemini client error: {e}")
+                  sys.exit(0)
+              except Exception as e:
+                  # Server-side 5xx (504 DEADLINE_EXCEEDED, 503 UNAVAILABLE) and
+                  # transport errors land here — worth retrying.
+                  last_err = e
 
-              # Save the generated image
+          if response is None:
+              print(f"::warning title=Cover image::Generation failed after retries: {last_err}")
+              sys.exit(0)
+
+          try:
+              # google.genai.types.Image is a raw-bytes wrapper, not a PIL.Image —
+              # only .save(path) is available. Save as PNG (Gemini's native format).
               for part in response.parts:
                   if hasattr(part, 'inline_data') and part.inline_data is not None:
                       image = part.as_image()
                       image.save("cover.png")
-                      print("Cover image generated successfully: cover.png")
+                      size_kb = os.path.getsize("cover.png") // 1024
+                      print(f"Cover image generated successfully: cover.png ({size_kb} KB)")
                       break
               else:
                   print("::warning title=Cover image::No image returned by Gemini (API may have rejected the prompt)")
                   sys.exit(0)
-
-          except ClientError as e:
-              if e.status_code == 429:
-                  print("::warning title=Cover image::Skipped — Gemini image model requires paid tier (free tier quota exceeded). See https://ai.google.dev/gemini-api/docs/pricing")
-                  sys.exit(0)
-              else:
-                  print(f"::warning title=Cover image::Gemini API error: {e}")
-                  sys.exit(0)
           except Exception as e:
-              # Includes httpx.ReadTimeout / TimeoutError from the 90s SDK timeout above.
-              print(f"::warning title=Cover image::Generation failed or timed out: {e}")
+              print(f"::warning title=Cover image::Failed to encode/save image: {e}")
               sys.exit(0)
           PY
+
+      - name: Optimize cover image
+        # Lossy palette quantization, same algorithm class as tinypng.com.
+        # ~60-70% smaller PNG with no perceptible quality loss for these
+        # marketing covers. No API key, no rate limit.
+        if: hashFiles('cover.png') != ''
+        run: |
+          set -euo pipefail
+          before=$(stat -c %s cover.png)
+          pngquant --quality=70-90 --speed 1 --strip --force --output cover.png cover.png
+          after=$(stat -c %s cover.png)
+          saved=$((100 - (after * 100 / before)))
+          printf 'cover.png: %d B -> %d B (-%d%%)\n' "$before" "$after" "$saved"
 
       - name: Upload cover image as artifact
         if: hashFiles('cover.png') != ''

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -353,12 +353,14 @@ jobs:
           selected_theme = visual_themes[theme_index]
 
           # Rotating composition styles
-          # Compositions push the focal object off-center so the title can
-          # render as a single uninterrupted block in the opposite half.
+          # Title and subtitle render as a single centered text block; the
+          # focal theme acts as backdrop or vertical accent, never competing
+          # with the centered text for horizontal real estate.
           composition_styles = [
-              "left-weighted with diagonal leading lines, focal object in the left third",
-              "right-weighted with S-curve flow, focal object in the right third",
-              "cinematic rule-of-thirds placement, focal object off-center",
+              "centered text block; focal theme as full-frame backdrop / texture across the entire image",
+              "centered text block; focal element placed above the text, smaller and supporting",
+              "centered text block; focal element placed below the text, smaller and supporting",
+              "centered text block; focal motifs softly mirrored on the far left and far right margins, framing the text",
           ]
           composition_index = (date_seed // 8) % len(composition_styles)
           selected_composition = composition_styles[composition_index]
@@ -406,9 +408,10 @@ jobs:
           - title: "{digest_title}" — LARGE bold typography occupying ~14% of frame height, dominant in the layout
           - subtitle: "{current_date}" — supporting text at ~6% of frame height, clearly readable
           - optional small caption: "{tagline}" — supporting text at ~4% of frame height
-          - the title is a SINGLE CONTINUOUS BLOCK — one line, or stacked lines as a unit; never split or interrupted by graphics
-          - text and the visual theme occupy DISTINCT zones of the frame; do not place focal objects between title words
-          - all text must be highly readable at thumbnail size; treat typography as the second focal element after the visual theme
+          - title, subtitle, and caption render as ONE centered text block — stacked vertically, all lines horizontally centered, group as a whole centered horizontally and vertically in the frame
+          - the title itself is a SINGLE CONTINUOUS line — never split or interrupted by graphics
+          - graphics never overlap or pass through the centered text block; keep the text zone clean
+          - all text must be highly readable at thumbnail size; treat typography as the primary focal element
           - high contrast against background; no thin or condensed typefaces
 
           COMPOSITION:
@@ -416,7 +419,7 @@ jobs:
           - {selected_composition}
           - strong focal object featuring {selected_theme}
           - {selected_lighting}
-          - expansive negative space for text overlay
+          - clean negative space directly behind the centered text block (no busy graphics under the text)
           - panoramic, sweeping composition
 
           QUALITY:

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -74,13 +74,13 @@ jobs:
           UNTIL_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           if [[ "$PERIOD" == "monthly" ]]; then
             SINCE_UTC="$(date -u -d '1 month ago' +%Y-%m-%dT%H:%M:%SZ)"
-            LABEL="Monthly digest"
+            LABEL="Armbian Monthly digest"
           elif [[ "$PERIOD" == "quarterly" ]]; then
             SINCE_UTC="$(date -u -d '3 months ago' +%Y-%m-%dT%H:%M:%SZ)"
-            LABEL="Quarterly digest"
+            LABEL="Armbian Quarterly digest"
           else
             SINCE_UTC="$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)"
-            LABEL="Weekly digest"
+            LABEL="Armbian Weekly digest"
           fi
           echo "UNTIL_UTC=$UNTIL_UTC" >> "$GITHUB_ENV"
           echo "SINCE_UTC=$SINCE_UTC" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- Release name now reads **Armbian Weekly digest** (and Monthly / Quarterly equivalents) instead of the generic "Weekly digest". Makes the source obvious in cross-repo notifications and release lists.
- `LABEL` is reused by the AI intro prompt and the cover-image prompt, so those stay coherent automatically.

## Test plan
- [x] Trigger workflow_dispatch with `period=weekly` → release titled "Armbian Weekly digest"
- [x] Trigger with `period=monthly` → release titled "Armbian Monthly digest"
- [ ] Trigger with `period=quarterly` → release titled "Armbian Quarterly digest"