### PR TITLE
Merge third-party armbian-images.json sources into the main download index

### DIFF
--- a/release-targets/third-party.yml
+++ b/release-targets/third-party.yml
@@ -1,0 +1,22 @@
+# Third-party sources of armbian-images.json. Each entry's `assets`
+# array is appended to the main armbian-images.json that this repo
+# publishes at https://github.armbian.com/armbian-images.json.
+#
+# An entry is a single string and may be either:
+#
+#   - a GitHub `<owner>/<repo>` shorthand
+#       Resolved to:
+#         https://github.com/<owner>/<repo>/releases/latest/download/armbian-images.json
+#       (so the third-party repo just needs to publish that file as
+#       a release asset on its `latest` release)
+#
+#   - a full `https://…` URL pointing directly at an armbian-images.json
+#
+# The third-party manifest must already be in the canonical schema
+# (`{"assets": [ {…}, … ]}`); no enrichment or transformation is done
+# on the merged rows. Failures (network, missing file, malformed JSON)
+# are logged as warnings and the merge continues with the remaining
+# sources.
+
+sources:
+  - armbian/sdk

--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -9,6 +9,7 @@ SOURCE_OF_TRUTH="${SOURCE_OF_TRUTH:-rsync://fi.mirror.armbian.de}"
 OS_DIR="${OS_DIR:-./os}"
 BOARD_DIR="${BOARD_DIR:-./build/config/boards}"
 REUSABLE_FILE="${REUSABLE_FILE:-./release-targets/reusable.yml}"
+THIRD_PARTY_FILE="${THIRD_PARTY_FILE:-./release-targets/third-party.yml}"
 OUT="${OUT:-armbian-images.json}"
 
 # -----------------------------------------------------------------------------
@@ -853,6 +854,68 @@ cat "$tmpdir/a.txt" "$tmpdir/bcd.txt" >"$feed"
   done <"$feed"
 
 } | jc --csv | jq '{assets:.}' >"$OUT"
+
+# -----------------------------------------------------------------------------
+# Merge third-party manifests
+# -----------------------------------------------------------------------------
+# Each entry in THIRD_PARTY_FILE points at an external `armbian-images.json`
+# (already in canonical schema). Their `.assets` arrays are concatenated
+# onto $OUT — no enrichment or row rewriting is done. Failures are logged
+# but do not abort the run.
+if [[ -f "$THIRD_PARTY_FILE" ]]; then
+  echo "▶ Merging third-party manifests from ${THIRD_PARTY_FILE}…" >&2
+
+  added_total=0
+  while IFS= read -r src; do
+    src="${src#"${src%%[![:space:]]*}"}"  # ltrim
+    src="${src%"${src##*[![:space:]]}"}"  # rtrim
+    [[ -z "$src" ]] && continue
+
+    if [[ "$src" == http://* || "$src" == https://* ]]; then
+      url="$src"
+    else
+      url="https://github.com/${src}/releases/latest/download/armbian-images.json"
+    fi
+
+    echo "  - ${src} → ${url}" >&2
+
+    tp_json="$(mktemp)"
+    if ! curl -fsSL --retry 3 --connect-timeout 10 "$url" -o "$tp_json"; then
+      echo "    WARNING: failed to fetch ${url}, skipping" >&2
+      rm -f "$tp_json"
+      continue
+    fi
+
+    if ! jq -e '.assets | type == "array"' "$tp_json" >/dev/null 2>&1; then
+      echo "    WARNING: ${url} is not in the expected schema (.assets array missing), skipping" >&2
+      rm -f "$tp_json"
+      continue
+    fi
+
+    added="$(jq '.assets | length' "$tp_json")"
+    jq -s '{assets: (.[0].assets + .[1].assets)}' "$OUT" "$tp_json" > "${OUT}.merged"
+    mv "${OUT}.merged" "$OUT"
+    added_total=$((added_total + added))
+    echo "    + ${added} assets" >&2
+    rm -f "$tp_json"
+  done < <(
+    python3 -c "
+import yaml, sys
+try:
+    with open('$THIRD_PARTY_FILE') as f:
+        data = yaml.safe_load(f) or {}
+    for src in (data.get('sources') or []):
+        if src is not None and str(src).strip():
+            print(str(src).strip())
+except Exception as e:
+    sys.stderr.write(f'Error loading third-party.yml: {e}\n')
+" 2>/dev/null || true
+  )
+
+  echo "  - Third-party assets added: ${added_total}" >&2
+else
+  echo "ℹ️  Third-party source list not found: ${THIRD_PARTY_FILE}" >&2
+fi
 
 # -----------------------------------------------------------------------------
 # Emit warnings for incomplete board metadata (non-fatal)


### PR DESCRIPTION
## Summary

Adds a config-driven hook that lets external repositories contribute their own `armbian-images.json` rows to the canonical index published at <https://github.armbian.com/armbian-images.json>.

- New file [release-targets/third-party.yml](release-targets/third-party.yml) lists sources. Each entry is either a GitHub `<owner>/<repo>` shorthand (resolved to that repo's `/releases/latest/download/armbian-images.json`) or a full `https://…` URL. Seeded with `armbian/sdk`.
- After [scripts/generate-armbian-images-json.sh](scripts/generate-armbian-images-json.sh) writes the main index, it iterates the YAML list, `curl`s each source, validates the `.assets` array shape, and merges with `jq -s '{assets: .[0].assets + .[1].assets}'`. No row rewriting, no enrichment — the third party is responsible for emitting canonical schema rows.
- Network errors, missing files, and malformed JSON are logged as per-source warnings; they do not abort the run, so a temporarily unreachable mirror cannot break the canonical index.

## Why

`armbian-images.json` is the single source of truth that the **[armbian website](https://www.armbian.com/download)** download pages and **[armbian imager](https://github.com/armbian/imager)** consume to discover what's available. Anything that isn't in that file simply doesn't show up.

Today the index only covers what `armbian/build`, `armbian/community`, `armbian/os`, `armbian/distribution`, and the rsync mirror publish. The new [armbian/sdk](https://github.com/armbian/sdk) repo publishes virtual machine images outside that path, and we want to give first-class downstream presence to:

- **Armbian-built images that live in their own repos** (the SDK today; potentially other side-channel image producers tomorrow), so they appear on the website's download list and inside Armbian Imager.
- **Trusted third-party publishers** that build their own Armbian-based images (vendor or community spin-offs), so users discover them through the same official channels instead of out-of-band links.

This PR is the minimum-effort way to surface those sources under the canonical index — without having to fork the producer side or special-case anything in the website / imager consumers.

Related: [armbian/imager#121](https://github.com/armbian/imager/issues/121).

## How third parties opt in

1. Publish an `armbian-images.json` (canonical `{"assets": [ … ]}` schema) as a release asset on their `latest` GitHub release. Anyone using the `armbian/build` composite action with the assets-manifest step gets this for free.
2. Open a PR against this repo adding their `<owner>/<repo>` to `release-targets/third-party.yml`.

## Test plan

- [ ] CI "Data: Generate Armbian download index" workflow run on this branch shows the `▶ Merging third-party manifests …` block in the log
- [ ] The line `+ N assets` appears for `armbian/sdk → …` (N matches the number of assets in the SDK's published manifest)
- [ ] Resulting `armbian-images.json` includes rows whose `board_slug` is `uefi-x86` / `uefi-arm64` (sourced from the SDK)
- [ ] Deliberately broken source (e.g. typo'd repo) only logs a warning and the run still succeeds
- [ ] Armbian Imager picks up the new rows on next refresh of its catalogue
- [ ] Website download pages render the new entries with no layout regressions