### PR TITLE
Community: blacklist xpressreal-t3 (resolute desktops failing)

### DIFF
--- a/release-targets/targets-release-community-maintained.blacklist
+++ b/release-targets/targets-release-community-maintained.blacklist
@@ -7,3 +7,4 @@ mekotronics-r58hd
 mekotronics-r58-4x4
 retroidpocket-rpmini
 retroidpocket-rp5
+xpressreal-t3


### PR DESCRIPTION
## Summary

Adds `xpressreal-t3` to [release-targets/targets-release-community-maintained.blacklist](release-targets/targets-release-community-maintained.blacklist). It is the only failing board in the most recent **Build Community Images (cronjob)** run on `armbian/os` and it failed both desktop matrix cells:

- `Xpressreal-t3_resolute_vendor_6.6.y_gnome_desktop`
- `Xpressreal-t3_resolute_vendor_6.6.y_kde-plasma_desktop`

Run: <https://github.com/armbian/os/actions/runs/25287402027>

Same resolute-desktop pattern as the boards added in #307. Remove once the resolute desktop builds for this board are green again.

## Test plan

- [x] Next community cronjob run on `armbian/os` skips xpressreal-t3.