### PR TITLE
Community: enable Ubuntu minimal CLI for all boards (not just headless)

### DIFF
--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -1813,10 +1813,14 @@ targets:
         if edge_riscv64:
             yaml += '      - *community-edge-riscv64\n'
 
-    # Ubuntu minimal CLI for headless community boards
-    if current_headless or vendor_headless or edge_headless:
+    # Ubuntu minimal CLI for all community boards (excluding loongarch).
+    # Mirrors community-trixie-all on the Debian side so every csc/tvb
+    # board gets a CLI Ubuntu image too, not just the headless ones.
+    if (current_fast or current_slow or current_headless or current_riscv64 or
+        vendor_fast or vendor_slow or vendor_headless or vendor_riscv64 or
+        edge_fast or edge_slow or edge_headless or edge_riscv64):
         yaml += """
-  # Ubuntu minimal CLI for headless community boards
+  # Ubuntu minimal CLI for all community boards
   community-noble-minimal:
     enabled: yes
     configs: [ armbian-community ]
@@ -1829,12 +1833,30 @@ targets:
       BUILD_DESKTOP: "no"
     items:
 """
+        if current_fast:
+            yaml += '      - *community-current-fast-hdmi\n'
+        if current_slow:
+            yaml += '      - *community-current-slow-hdmi\n'
         if current_headless:
             yaml += '      - *community-current-headless\n'
+        if current_riscv64:
+            yaml += '      - *community-current-riscv64\n'
+        if vendor_fast:
+            yaml += '      - *community-vendor-fast-hdmi\n'
+        if vendor_slow:
+            yaml += '      - *community-vendor-slow-hdmi\n'
         if vendor_headless:
             yaml += '      - *community-vendor-headless\n'
+        if vendor_riscv64:
+            yaml += '      - *community-vendor-riscv64\n'
+        if edge_fast:
+            yaml += '      - *community-edge-fast-hdmi\n'
+        if edge_slow:
+            yaml += '      - *community-edge-slow-hdmi\n'
         if edge_headless:
             yaml += '      - *community-edge-headless\n'
+        if edge_riscv64:
+            yaml += '      - *community-edge-riscv64\n'
 
     # Note: loongarch boards don't get noble images, only bookworm minimal
 


### PR DESCRIPTION
## Summary

`community-noble-minimal` previously only covered **headless** community boards (csc/tvb without HDMI). Mirror the Debian-side `community-trixie-all` block so every community board gets a minimal Ubuntu CLI image alongside the existing minimal Debian one.

Boards that gain an Ubuntu minimal CLI build:

- `current` / `vendor` / `edge` × `fast-hdmi` / `slow-hdmi` / `riscv64`

(headless boards already had it; loongarch stays excluded — the existing note still applies: noble images aren't produced for loongarch, only bookworm minimal).

## Why

The community feed already produces Debian minimal CLI for every csc/tvb board (`community-trixie-all`) and Ubuntu desktops for the boards with display output. The asymmetry meant a community board with HDMI got Ubuntu **only** as a desktop build — never minimal. Users who want Ubuntu CLI on those boards had to switch to the Debian image. This closes the gap.

## How

Single edit in [`scripts/generate_targets.py`](scripts/generate_targets.py): expanded the gating condition + items list of `community-noble-minimal` from the headless trio to the same `current/vendor/edge × fast-hdmi/slow-hdmi/headless/riscv64` set used by `community-trixie-all`.

## Test plan

- [ ] `python3 scripts/generate_targets.py` (or however the CI runs it) regenerates `targets-release-community-maintained.yaml` without errors.
- [ ] The regenerated YAML's `community-noble-minimal:` block has items pointing at `community-current-fast-hdmi`, `community-vendor-fast-hdmi`, …, `community-edge-riscv64` (not just the three headless aliases).
- [ ] Next community cronjob run on `armbian/os` shows Ubuntu minimal CLI cells for HDMI / slow-HDMI / riscv64 community boards.
- [ ] No loongarch entry appears in the Ubuntu block.