### PR TITLE
ci: dispatch armbian/website sync after web-directory generation

### DIFF
--- a/.github/workflows/infrastructure-dispatch-website-sync.yml
+++ b/.github/workflows/infrastructure-dispatch-website-sync.yml
@@ -1,0 +1,48 @@
+name: "Infrastructure: Dispatch website sync"
+run-name: Dispatch armbian/website sync after ${{ github.event.workflow_run.name || github.workflow }}
+
+# Watches for the github.armbian.com content generator to finish,
+# then fires a repository_dispatch at armbian/website so the public
+# site rebuilds against the freshly published directory listing.
+# Mirrors the peter-evans/repository-dispatch pattern already used
+# for cross-repo dispatch from this repo (generate-actions-report.yml).
+on:
+  workflow_run:
+    workflows: ["Web: Generate github.armbian.com content"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: 📢 Trigger website sync
+    runs-on: ubuntu-latest
+    # Only fire from the canonical repo (skip forks) AND only when
+    # the upstream generator actually succeeded — partial / red runs
+    # would push incomplete data to production. Manual
+    # workflow_dispatch is always allowed for one-off retries.
+    if: >-
+      ${{ github.repository_owner == 'armbian'
+          && (github.event_name == 'workflow_dispatch'
+              || github.event.workflow_run.conclusion == 'success') }}
+    env:
+      DISPATCH: ${{ secrets.DISPATCH }}
+    steps:
+      - name: Fire repository_dispatch on armbian/website
+        # Soft-skip when the secret isn't configured rather than
+        # failing red.
+        if: ${{ env.DISPATCH != '' }}
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ env.DISPATCH }}
+          repository: armbian/website
+          event-type: sync
+          client-payload: >-
+            {
+              "source_workflow": "${{ github.event.workflow_run.name || github.workflow }}",
+              "source_run_id":   "${{ github.event.workflow_run.id   || github.run_id }}",
+              "source_repo":     "${{ github.repository }}",
+              "source_sha":      "${{ github.event.workflow_run.head_sha || github.sha }}"
+            }

--- a/.github/workflows/infrastructure-dispatch-website-sync.yml
+++ b/.github/workflows/infrastructure-dispatch-website-sync.yml
@@ -10,6 +10,10 @@ on:
   workflow_run:
     workflows: ["Web: Generate github.armbian.com content"]
     types: [completed]
+    # Only react to runs of the generator on the production branch.
+    # Without this filter, any feature/test-branch run of the
+    # generator could trigger a dispatch at armbian/website.
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
After [`Web: Generate github.armbian.com content`](.github/workflows/generate-web-directory.yml) finishes, fire a `repository_dispatch` at [`armbian/website`](https://github.com/armbian/website/blob/main/.github/workflows/website-sync.yml) so the public site rebuilds against the freshly published directory listing.

Same shape this repo already uses for cross-repo dispatch — see [`generate-actions-report.yml`](.github/workflows/generate-actions-report.yml). `peter-evans/repository-dispatch@v4` + `secrets.DISPATCH` org PAT.

## Behaviour matrix

| Trigger                                                    | Owner       | Upstream conclusion | Secret set | Action |
|------------------------------------------------------------|-------------|---------------------|------------|--------|
| `workflow_run` after `Web: Generate github.armbian.com…`   | `armbian`   | `success`           | yes        | dispatch |
| same                                                       | `armbian`   | `success`           | no         | step soft-skips |
| same                                                       | `armbian`   | failure / cancelled | —          | job skipped (`if`) |
| same                                                       | fork owner  | any                 | —          | job skipped (`if`) |
| Manual `workflow_dispatch`                                 | `armbian`   | n/a                 | yes        | dispatch |

## Why gate on `conclusion == 'success'`
A red generator run would push partial / inconsistent directory data; rebuilding the production site against that state surfaces broken pages. Better to no-op until the generator is green.

## Event type
`sync` — matches the [listener at line 4](https://github.com/armbian/website/blob/main/.github/workflows/website-sync.yml) of the target workflow.

## Test plan
- [ ] Merge to main; trigger a manual `workflow_dispatch` of this new workflow as a smoke test.
- [ ] Confirm the dispatch lands by watching `Website: Trigger data sync` runs in `armbian/website`.
- [ ] Trigger `Web: Generate github.armbian.com content`; verify this workflow fires only when the generator succeeded and the target workflow runs.
- [ ] Confirm a forked clone running this workflow no-ops (no spurious dispatches at `armbian/website`).