### PR TITLE
ci: fix dispatch chain — download-index fan-out + redirector ends with directory regen

### DIFF
--- a/.github/workflows/data-update-download-index.yml
+++ b/.github/workflows/data-update-download-index.yml
@@ -144,6 +144,12 @@ jobs:
             exit 1
           fi
 
+      - name: "Update redirector config"
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.DISPATCH }}
+          event-type: "Infrastructure: Update redirector"
+
       - name: "Generate directory"
         uses: peter-evans/repository-dispatch@v4
         with:

--- a/.github/workflows/data-update-download-index.yml
+++ b/.github/workflows/data-update-download-index.yml
@@ -148,4 +148,4 @@ jobs:
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.DISPATCH }}
-          event-type: "Infrastructure: Update redirector"
+          event-type: "Web: Directory listing"

--- a/.github/workflows/infrastructure-update-redirector-config.yml
+++ b/.github/workflows/infrastructure-update-redirector-config.yml
@@ -719,5 +719,17 @@ jobs:
     - name: "Run webindex update action"
       uses: peter-evans/repository-dispatch@v4
       with:
+        # GITHUB_TOKEN here is intentional — it's suppressed by
+        # GitHub for same-repo dispatches, which is what breaks the
+        # would-be loop redirector → download-index → redirector
+        # (download-index dispatches 'Infrastructure: Update redirector'
+        # via the org PAT). Don't switch to DISPATCH without first
+        # rewiring the chain elsewhere.
         token: ${{ secrets.GITHUB_TOKEN }}
         event-type: "Data: Update download index"
+
+    - name: "Generate directory"
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        token: ${{ secrets.DISPATCH }}
+        event-type: "Web: Directory listing"

--- a/.github/workflows/infrastructure-update-redirector-config.yml
+++ b/.github/workflows/infrastructure-update-redirector-config.yml
@@ -722,14 +722,8 @@ jobs:
         # GITHUB_TOKEN here is intentional — it's suppressed by
         # GitHub for same-repo dispatches, which is what breaks the
         # would-be loop redirector → download-index → redirector
-        # (download-index dispatches 'Infrastructure: Update redirector'
-        # via the org PAT). Don't switch to DISPATCH without first
-        # rewiring the chain elsewhere.
+        # (download-index now dispatches 'Infrastructure: Update
+        # redirector' via the org PAT). Don't switch to DISPATCH
+        # without first rewiring the chain elsewhere.
         token: ${{ secrets.GITHUB_TOKEN }}
         event-type: "Data: Update download index"
-
-    - name: "Generate directory"
-      uses: peter-evans/repository-dispatch@v4
-      with:
-        token: ${{ secrets.DISPATCH }}
-        event-type: "Web: Directory listing"

--- a/.github/workflows/infrastructure-update-redirector-config.yml
+++ b/.github/workflows/infrastructure-update-redirector-config.yml
@@ -716,14 +716,8 @@ jobs:
             archive
             cache
 
-    - name: "Run webindex update action"
+    - name: "Generate directory"
       uses: peter-evans/repository-dispatch@v4
       with:
-        # GITHUB_TOKEN here is intentional — it's suppressed by
-        # GitHub for same-repo dispatches, which is what breaks the
-        # would-be loop redirector → download-index → redirector
-        # (download-index now dispatches 'Infrastructure: Update
-        # redirector' via the org PAT). Don't switch to DISPATCH
-        # without first rewiring the chain elsewhere.
-        token: ${{ secrets.GITHUB_TOKEN }}
-        event-type: "Data: Update download index"
+        token: ${{ secrets.DISPATCH }}
+        event-type: "Web: Directory listing"


### PR DESCRIPTION
## What this PR fixes

Two related dispatches around the public download index / directory listing were either pointing at the wrong listener or were no-ops.

### 1. \`data-update-download-index.yml\` — \"Generate directory\" step targeted the wrong workflow
The final step was named **\"Generate directory\"** but dispatched \`event-type: \"Infrastructure: Update redirector\"\` — which fires [\`infrastructure-update-redirector-config.yml\`](.github/workflows/infrastructure-update-redirector-config.yml), not [\`generate-web-directory.yml\`](.github/workflows/generate-web-directory.yml). The directory regen never ran after a download-index update.

Split into two correctly named/typed steps so both downstream workflows fire:

\`\`\`yaml
- name: \"Update redirector config\"
  event-type: \"Infrastructure: Update redirector\"   # → infrastructure-update-redirector-config.yml

- name: \"Generate directory\"
  event-type: \"Web: Directory listing\"             # → generate-web-directory.yml
\`\`\`

### 2. \`infrastructure-update-redirector-config.yml\` — Close job tail dispatch was a no-op
The Close job ended with a \`Run webindex update action\` step that used \`GITHUB_TOKEN\` to dispatch \`Data: Update download index\`. GitHub suppresses GITHUB_TOKEN-fired dispatches for same-repo listeners, so it was effectively a no-op.

Replace with a \`Generate directory\` step that dispatches \`Web: Directory listing\` via the org PAT — which is what should happen after the redirector publishes new YAML to the \`data\` branch.

## Resulting graph (loop-free)

\`\`\`
download-index → redirector + directory
redirector     → directory
\`\`\`

No \`redirector → download-index\` arrow at all (was suppressed before, removed now), so no loop is possible.

## Test plan
- [ ] \`workflow_dispatch\` on \`Data: Generate Armbian download index\`. Expect:
  - [ ] \`Infrastructure: Update CDN redirector\` runs.
  - [ ] \`Web: Generate github.armbian.com content\` runs.
  - [ ] No second \`download-index\` run is spawned.
- [ ] \`workflow_dispatch\` on \`Infrastructure: Update CDN redirector\`. Expect:
  - [ ] \`Web: Generate github.armbian.com content\` runs.
  - [ ] No \`download-index\` re-run.