### PR TITLE
docs: README diagram of the download / directory dispatch chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,40 @@ Monitor all automation workflows with real-time status tracking:
 - **Live status** — Current state of running CI/CD pipelines and scheduled tasks
 - **Debugging tools** — Detailed logs and error traces for failed workflows
 
+### Download / directory dispatch chain
+
+How a fresh release ripples through the automation. Solid arrows fire; the dotted arrow is intentionally suppressed by GitHub's `GITHUB_TOKEN` same-repo guard (it's the loop-breaker — without it, `redirector ↔ download-index` would cycle forever).
+
+```mermaid
+flowchart TD
+  manual([manual workflow_dispatch / schedule]):::ext
+  sdk[armbian/sdk<br/>Build Armbian SDK]:::ext
+
+  manual --> dl
+  manual --> redir
+  manual --> dir
+  sdk -. repository_dispatch<br/>'Data: Update download index' .-> dl
+
+  subgraph ghio [armbian/armbian.github.io]
+    dl[Data: Generate Armbian download index]:::wf
+    redir[Infrastructure: Update CDN redirector]:::wf
+    dir[Web: Generate github.armbian.com content]:::wf
+    syncDispatch[Infrastructure: Dispatch website sync]:::wf
+
+    dl -- repository_dispatch<br/>'Infrastructure: Update redirector' --> redir
+    dl == commit to data branch ==> dir
+    redir == commit to data branch ==> dir
+    redir -. GITHUB_TOKEN suppressed<br/>'Data: Update download index' .-> dl
+
+    dir -- workflow_run completed --> syncDispatch
+  end
+
+  syncDispatch -- repository_dispatch<br/>'sync' --> websiteSync
+  websiteSync[armbian/website<br/>Website: Trigger data sync]:::ext
+
+  classDef ext fill:#f5f5f5,stroke:#999,color:#333,font-style:italic;
+  classDef wf fill:#e0f2fe,stroke:#0369a1,color:#0c4a6e;
+```
+
+Beyond this chain, several smaller producers (`data-update-image-info`, `data-update-base-files-info`, `data-update-jira-excerpt`, `data-update-partners-data`, `generate-build-lists`, `generate-keyring-data`, `generate-servers-jsons`, `generate-torrent-tracker-lists`, `repository-status`) all dispatch `Web: Directory listing` via `GITHUB_TOKEN`. Those dispatches are suppressed by the same-repo guard — `generate-web-directory` regenerates from the underlying `data` branch push instead.
+


### PR DESCRIPTION
## Summary
Add a Mermaid flowchart to the [README](README.md) showing how a fresh release ripples through the automation across `armbian/sdk` → `armbian/armbian.github.io` → `armbian/website`. Mermaid renders natively in GitHub-flavoured markdown.

## Why
Newcomers (and me, after a week away) keep having to reverse-engineer the dispatch chain by grepping for `repository-dispatch` across repos. One picture in the README makes the live-vs-suppressed picture explicit:

- Solid arrows = dispatches that actually fire.
- Dotted arrow = intentionally suppressed by GitHub's `GITHUB_TOKEN` same-repo guard. Calls out that the suppression is **load-bearing** — without it, `redirector ↔ download-index` would loop forever.
- Footnote enumerates other `Web: Directory listing` producers that are also `GITHUB_TOKEN`-suppressed, so readers don't expect them to drive `generate-web-directory` directly (the data-branch push trigger does).

## Test plan
- [ ] Open the rendered README on GitHub; confirm the Mermaid diagram renders (not an inert code block).
- [ ] Confirm node labels and edge labels are legible at default GitHub width.