### PR TITLE
ci: cancel in-flight download-index runs when a new one starts

### DIFF
--- a/.github/workflows/data-update-download-index.yml
+++ b/.github/workflows/data-update-download-index.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   SOURCE_OF_TRUTH: "rsync://fi.mirror.armbian.de"


### PR DESCRIPTION
## Summary
One-line concurrency tweak on [\`data-update-download-index.yml\`](.github/workflows/data-update-download-index.yml):

\`\`\`diff
 concurrency:
   group: \${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
\`\`\`

## Why
A fresh trigger (SDK build dispatch, release publish, manual retry) currently has to wait behind any older run still mid-rsync against \`fi.mirror.armbian.de\`. Two consequences:
- The mirror connection from the stale run stays open for its full duration — wasted slot.
- If a slow run eventually finishes after a newer one was queued, yesterday's index can land over today's.

Cancelling the in-flight run on every new trigger preempts both: the freshest data wins, and the rsync slot frees immediately.

The commit step at the bottom of the job writes \`armbian-images.json\` + \`all-torrents.zip\` atomically to the \`data\` branch — a cancelled run leaves nothing half-written.

## Test plan
- [ ] Trigger \`Data: Generate Armbian download index\` manually, then trigger it again before the first finishes; confirm the older run shows \"Cancelled\" in the run list.
- [ ] Confirm the newer run completes and lands a fresh \`armbian-images.json\` on \`data\`.