### PR TITLE
release-targets: flip UEFI desktop spins from current to edge

### DIFF
--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -104,8 +104,8 @@ desktop-stable-ubuntu-cinnamon-uefi:
     DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
-    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
-    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
+    - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
     - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
@@ -126,8 +126,8 @@ desktop-stable-ubuntu-kde-plasma-uefi:
     DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
-    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
-    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
+    - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
 
 # Ubuntu MATE desktop - UEFI only
 desktop-stable-ubuntu-mate-uefi:
@@ -145,8 +145,8 @@ desktop-stable-ubuntu-mate-uefi:
     DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
-    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
-    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
+    - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
 
 # Ubuntu Xfce desktop - UEFI only
 desktop-stable-ubuntu-xfce-uefi:
@@ -164,8 +164,8 @@ desktop-stable-ubuntu-xfce-uefi:
     DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
-    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
-    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
+    - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
 
 # Ubuntu i3 window-manager - UEFI only
 desktop-stable-ubuntu-i3-wm-uefi:
@@ -183,5 +183,5 @@ desktop-stable-ubuntu-i3-wm-uefi:
     DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
-    - { BOARD: uefi-arm64, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
-    - { BOARD: uefi-x86, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
+    - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
+    - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }


### PR DESCRIPTION
GNOME UEFI desktops already build against edge; the other five UEFI desktop spins (cinnamon, kde-plasma, mate, xfce, i3-wm) stayed on current. Flip them so every UEFI desktop spin tracks the same kernel branch.

## Motivation

Edge has the recent Lunar Lake hardware enablement that current doesn't pick up yet:

- iwlwifi MLD (BE201 / Wi-Fi 7)
- SOF Intel LNL / MTL / PTL audio + CS35L56 SPI amps
- IPU7 + OV02C10/OV02E10 sensors

Owners of recent UEFI laptops (ThinkPad X9-14/X9-15 Gen 1, X1 Carbon Gen 13, T14s LNL, …) currently build the GNOME edge spin or get a desktop with silent speakers / missing camera. Aligning the rest of the DE matrix with GNOME fixes that.

## Changes

Five sections, two rows each:

| Section | uefi-arm64 | uefi-x86 |
|---|---|---|
| desktop-stable-ubuntu-cinnamon-uefi | current → edge | current → edge |
| desktop-stable-ubuntu-kde-plasma-uefi | current → edge | current → edge |
| desktop-stable-ubuntu-mate-uefi | current → edge | current → edge |
| desktop-stable-ubuntu-xfce-uefi | current → edge | current → edge |
| desktop-stable-ubuntu-i3-wm-uefi | current → edge | current → edge |

Minimal targets (\`minimal-stable-ubuntu-current-uefi\`, \`-noble-current-uefi\`) stay on current as designed — those are the explicit current-kernel CLI track.

## Test plan

- [ ] CI builds all five flipped spins on edge and uploads successfully
- [ ] On a ThinkPad X9-class machine, the new XFCE / KDE / etc. spins boot with working speakers + camera (vs current's broken state)
- [ ] No regression on non-LNL UEFI hosts (older Intel desktops, AMD UEFI machines) — edge has been the GNOME default already, no surprises expected