### PR TITLE
expose: switch uefi-x86 / uefi-arm64 to GNOME desktop on edge kernel

### DIFF
--- a/release-targets/exposed.map.overrides.yaml
+++ b/release-targets/exposed.map.overrides.yaml
@@ -68,3 +68,17 @@ overrides:
     minimal:
       release: trixie
       branch: current
+
+  - boards: [uefi-x86, uefi-arm64]
+    # Generic UEFI x86_64 / aarch64 images: expose the GNOME desktop
+    # built against the edge kernel.
+    #   - uefi-x86 defaults to gnome_desktop already (amd64=fast+video),
+    #     so this entry's effective change is branch current → edge.
+    #   - uefi-arm64 defaults to xfce_desktop (arm64=slow+video), so
+    #     this entry switches both the suffix AND the branch — we
+    #     want GNOME exposed for arm64 UEFI, not XFCE.
+    # Release stays at the standard Ubuntu codename (resolute) via
+    # field-level fall-through.
+    desktop:
+      branch: edge
+      suffix: gnome_desktop


### PR DESCRIPTION
## Summary
- Adds a per-board override in `release-targets/exposed.map.overrides.yaml` so the recommended desktop image surfaced on the website for the two generic UEFI boards is the GNOME spin built against the edge kernel.
- `uefi-x86` already defaulted to `gnome_desktop` (amd64 = fast+video); effective change for x86 is **branch current → edge**.
- `uefi-arm64` defaulted to `xfce_desktop` (arm64 = slow+video); this override flips **both** the suffix and the branch so the exposed image is **GNOME on edge**.
- Release stays at the standard Ubuntu codename (resolute) via the field-level fall-through in `match_exposed_override()`, so we don't spell `release:` out.

## Test plan
- [ ] Regenerate `exposed.map` and confirm the uefi-x86 / uefi-arm64 desktop entries point at `*_edge_gnome_desktop*` (matching the actual edge GNOME image filenames produced by armbian/os).
- [ ] Visit the website preview and confirm both boards' download cards link to the GNOME edge image rather than the previous defaults.