### PR TITLE
feat(release-summary): run AI intro & cover image for all periods

### DIFF
--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -205,7 +205,6 @@ jobs:
           echo "VERSION_OVERRIDE=${VERSION}" >> "$GITHUB_ENV"
 
       - name: "Write a short journalistic intro with AI"
-        if: ${{ env.PERIOD == 'weekly' || env.PERIOD == 'monthly' }}
         run: |
           set -euo pipefail
           python3 <<'PY'
@@ -286,7 +285,6 @@ jobs:
         run: cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: "Generate AI cover image"
-        if: ${{ env.PERIOD == 'weekly' || env.PERIOD == 'monthly' }}
         # 10m ceiling = headroom for 2x 240s SDK timeout + 30s retry wait + buffer.
         timeout-minutes: 10
         continue-on-error: true


### PR DESCRIPTION
## Summary

The Claude intro and Gemini cover-image steps in `reporting-release-summary.yml` were gated to `weekly` + `monthly` periods only. Quarterly digests therefore shipped as a bare PR list with no narrative intro and no banner. Drop the `if:` guards so both AI steps run for every period.

## Safety

- The Gemini step already has `continue-on-error: true` and a 10-min timeout, so a failure (paid-tier quota exhaustion, prompt rejection, transient 5xx after retry) won't fail the release publish.
- The Claude step has no retry, so an `ANTHROPIC_API_KEY` issue would now fail quarterly runs too — same blast radius as the existing weekly path.

## Test plan

- [x] Manually trigger `Reporting: Release summary` with `period=quarterly` → confirm AI intro is prepended to `summary.md` and `cover.png` is attached to the release
- [x] Existing weekly cron continues to produce the same output