### PR TITLE
runners: derive host from github_label custom field

### DIFF
--- a/.github/workflows/generate-servers-jsons.yml
+++ b/.github/workflows/generate-servers-jsons.yml
@@ -125,7 +125,7 @@ jobs:
             | map(
                 select(.name != null and ((.role.name? // "") == "Userlevel runner"))
                 | {
-                    host: (.custom_fields["github_label"] // .name),
+                    host: ((.custom_fields["github_label"] // "" | gsub("^\\s+|\\s+$";"") | select(. != "")) // .name),
                     runners: (.custom_fields["runners"] // 0),
                     vcpus: ((.vcpus // 0) | round),
                     memory: (.memory // 0),

--- a/.github/workflows/generate-servers-jsons.yml
+++ b/.github/workflows/generate-servers-jsons.yml
@@ -125,7 +125,7 @@ jobs:
             | map(
                 select(.name != null and ((.role.name? // "") == "Userlevel runner"))
                 | {
-                    host: .name,
+                    host: (.custom_fields["github_label"] // .name),
                     runners: (.custom_fields["runners"] // 0),
                     vcpus: ((.vcpus // 0) | round),
                     memory: (.memory // 0),


### PR DESCRIPTION
## What

In `github-runners.jq`, the runner's `host` (its identity/key) now comes from the **`github_label`** custom field instead of the VM `.name`:

```diff
- host: .name,
+ host: (.custom_fields["github_label"] // .name),
```

Falls back to `.name` when `github_label` is unset, so runners without the field keep their current key.

## Why it matters downstream

`host` is the key the `runner-clean` action matches on (`runner.name` minus the `-NN` index → compared to `host`'s first dotted segment). So `github_label` values should align with the runners' GitHub name base for the proxy/cache lookup to resolve.

## Validation

- YAML parses.
- jq verified: `github_label` present → used as host; absent → `.name`; non-runner roles excluded.