### PR TITLE
ci: board-asset validation — transparent background + object-size + full monthly scan

### DIFF
--- a/scripts/validate-board-assets.sh
+++ b/scripts/validate-board-assets.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Validate images in PRs:
-# - board-images/: must be 16:9 AND either 1920x1080 or 3840x2160
+# Validate images:
+# - board-images/: 16:9 AND either 1920x1080 or 3840x2160, TRANSPARENT background,
+#   and (optional) object not larger than MAX_OBJECT_PCT of the frame
 # - board-vendor-logos/: must be square (WxH equal)
 #
-# Requires ImageMagick's `identify`.
+# On a PR only the changed assets are checked; on schedule/workflow_dispatch the
+# WHOLE set is checked. Requires ImageMagick's `identify`/`convert`.
+#
+# env: MAX_OBJECT_PCT (int) — if set, fail a board image whose opaque-pixel fill
+#      exceeds this %. Unset = report only (board images currently fill 5–48%).
 
 BASE_REF="${BASE_REF:-origin/${GITHUB_BASE_REF:-main}}"
 HEAD_REF="${HEAD_REF:-HEAD}"
@@ -13,11 +18,20 @@ HEAD_REF="${HEAD_REF:-HEAD}"
 # Fetch base ref if needed (useful on CI with shallow clones)
 git fetch --no-tags --prune --depth=50 origin "+refs/heads/*:refs/remotes/origin/*" >/dev/null 2>&1 || true
 
-mapfile -t CHANGED < <(git diff --name-only "${BASE_REF}...${HEAD_REF}" -- \
-  'board-images/**' 'board-vendor-logos/**' || true)
+# On a PR, validate only the changed assets. On schedule / workflow_dispatch /
+# local (no PR base ref) validate EVERY asset, so the monthly run actually checks
+# the whole set instead of an empty diff.
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  mapfile -t CHANGED < <(git diff --name-only "${BASE_REF}...${HEAD_REF}" -- \
+    'board-images/**' 'board-vendor-logos/**' || true)
+  echo "Mode: changed files (PR vs ${GITHUB_BASE_REF})"
+else
+  mapfile -t CHANGED < <(find board-images board-vendor-logos -type f | sort)
+  echo "Mode: all assets"
+fi
 
 if [[ ${#CHANGED[@]} -eq 0 ]]; then
-  echo "No changes in board-images/ or board-vendor-logos/. ✅"
+  echo "No board-images/ or board-vendor-logos/ files to validate. ✅"
   exit 0
 fi
 
@@ -39,6 +53,25 @@ if ! command -v identify >/dev/null 2>&1; then
   echo "ERROR: 'identify' not found. Install ImageMagick."
   exit 2
 fi
+
+# Background is transparent iff there's an alpha channel AND all four corners are
+# (near) fully transparent. Returns 0 when transparent.
+bg_transparent() {
+  local f="$1" a tl tr bl br
+  a="$(identify -format '%A' "$f" 2>/dev/null || echo None)"
+  case "$a" in True|Blend|true|blend) : ;; *) return 1 ;; esac
+  tl=$(convert "$f" -format '%[fx:p{0,0}.a]'     info: 2>/dev/null || echo 1)
+  tr=$(convert "$f" -format '%[fx:p{w-1,0}.a]'   info: 2>/dev/null || echo 1)
+  bl=$(convert "$f" -format '%[fx:p{0,h-1}.a]'   info: 2>/dev/null || echo 1)
+  br=$(convert "$f" -format '%[fx:p{w-1,h-1}.a]' info: 2>/dev/null || echo 1)
+  awk -v a="$tl" -v b="$tr" -v c="$bl" -v d="$br" \
+    'BEGIN{exit !(a<0.04 && b<0.04 && c<0.04 && d<0.04)}'
+}
+
+# Object fill = % of the canvas that is opaque (non-transparent) pixels.
+object_fill_pct() {
+  convert "$1" -alpha extract -format '%[fx:round(mean*100)]' info: 2>/dev/null || echo 100
+}
 
 fail=0
 
@@ -63,7 +96,21 @@ check_board_image() {
     return 1
   fi
 
-  echo "✅ $file: OK (${w}x${h})"
+  # Background must be transparent (board photo cut out, not a flat backdrop).
+  if ! bg_transparent "$file"; then
+    echo "❌ $file: background must be transparent (no alpha channel or opaque corners)"
+    return 1
+  fi
+
+  # Object size: report the opaque-pixel fill %, and fail only if a limit is set.
+  local fill
+  fill=$(object_fill_pct "$file")
+  if [[ -n "${MAX_OBJECT_PCT:-}" && "$fill" -gt "${MAX_OBJECT_PCT}" ]]; then
+    echo "❌ $file: object too large — fills ${fill}% of the frame (max ${MAX_OBJECT_PCT}%)"
+    return 1
+  fi
+
+  echo "✅ $file: OK (${w}x${h}, transparent, object ${fill}%)"
   return 0
 }
 


### PR DESCRIPTION
## What

Extends `scripts/validate-board-assets.sh` (the *Infrastructure: Validate board images & vendor logos* workflow):

1. **Transparent background required** for `board-images/` — fails if the image has no alpha channel or its corners are opaque (a board photo should be cut out, not on a flat backdrop). Catches e.g. #332.
2. **Object size measured** — prints each board image's opaque-pixel fill %, and fails when it exceeds `MAX_OBJECT_PCT`. Unset = report-only for now (current images fill **5–48%**; an opaque/oversized one is **100%**), so ~55–60% is a clean future cutoff.
3. **Monthly run now scans everything** — on `schedule`/`workflow_dispatch` there's no PR base ref, so the old diff was empty and validated nothing; it now validates **all** assets. On PRs it still checks only changed files.

## Heads-up: pre-existing violations the full scan surfaces

These already-merged assets fail the rules and should be fixed (being handled separately, by hand):

- **Board images, wrong dimensions** (need 1920×1080 or 3840×2160): `armsom-sige3` (1919×1080), `bigtreetech-cb2` (1900×1080), `jethubj80`, `mba8mpxl`, `mba8mpxl-ras314`, `mekotronics-r58x-4g`, `thinkpad-x13s`, `youyeetoo-yy3588` (2048×1152), `radxa-dragon-q6a` (2048×1214), `xiaomi-elish` (1280×729)
- **Vendor logo, not square**: `huawei-logo.png` (512×520)

Transparency is clean across all current board images.

This PR changes only the script, so its own PR validation (changed files = none) passes.