### PR TITLE
ci: push image-info data branch direct to github (bypass git cache proxy)

### DIFF
--- a/.github/workflows/data-update-image-info.yml
+++ b/.github/workflows/data-update-image-info.yml
@@ -52,6 +52,13 @@ jobs:
           set -euo pipefail
           cd armbian.github.io
 
+          # The self-hosted 'super' runners rewrite github.com -> the read-only
+          # git cache proxy (git_proxy, 10.0.40.x) via a global insteadOf. That
+          # cache can't push ("could not read Username for 'http://...'"), so
+          # ignore global/system git config here and go DIRECT to github — the
+          # checkout auth token is in the repo-LOCAL config, so it still works.
+          export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
 


### PR DESCRIPTION
The scheduled **Data: Generate build engine inventory** job fails to push:

```
fatal: could not read Username for 'http://10.0.40.2:8000': No such device or address
Failed to push after 3 attempts
```

The `super` self-hosted runners rewrite `github.com` → the read-only **git cache proxy** (`git_proxy`, 10.0.40.x) via a global `insteadOf`. That cache is fetch-only; `git push` to it asks for a username and dies, so the `data` branch never gets the updated `image-info.json`.

**Fix:** in the *Commit changes if any* step, set `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` so `git fetch`/`push` go **direct to github**. The checkout auth token lives in the repo-**local** config, so authentication is unaffected — only the proxy rewrite is dropped.