### PR TITLE
scripts: fix js-yaml ESM default-import break in actions report

### DIFF
--- a/scripts/generate-actions-report.mjs
+++ b/scripts/generate-actions-report.mjs
@@ -53,7 +53,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import fg from "fast-glob";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml"; // namespace import: works for both CJS js-yaml (v4) and the ESM-only v5+ (no default export)
 import crypto from "node:crypto";
 import { execSync } from "node:child_process";
 


### PR DESCRIPTION
## Why the scheduled run fails

[Run 28012787633](https://github.com/armbian/armbian.github.io/actions/runs/28012787633) (and every scan job) dies at **Generate report**:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job)
```

No code changed — it's a **dependency drift**. `js-yaml` isn't pinned (no `package.json`/lockfile in the repo), so a fresh install pulled the new **ESM-only major**, which exports `load`/`dump` as *named* exports with **no `default`**. `scripts/generate-actions-report.mjs` did `import yaml from "js-yaml"` (a default import), which now throws.

## Fix

`import yaml from "js-yaml"` → **`import * as yaml from "js-yaml"`**. The only usage is `yaml.load()` (line 712), and the namespace form resolves `yaml.load` on **both** the old CJS v4 (via Node's CJS↔ESM interop) and the new ESM build — so it's robust to the version either way.

`node --check` passes. One-line change; no behavior change.

Optional follow-up (not in this PR): add a `package.json` + lockfile pinning `js-yaml` so the install can't drift again.