### PR TITLE
clean-workflow-logs: pass GITHUB_TOKEN explicitly

### DIFF
--- a/.github/workflows/maintenance-clean-workflow-logs.yml
+++ b/.github/workflows/maintenance-clean-workflow-logs.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - uses: igorjs/gh-actions-clean-workflow@v7
         with:
+          # Pass the token explicitly from the workflow context. The action's own
+          # `default: ${{ github.token }}` is not substituted on our self-hosted
+          # runner, so it arrives empty and fails validation; an explicit
+          # secrets.GITHUB_TOKEN resolves correctly (matches the other workflows).
+          token: ${{ secrets.GITHUB_TOKEN }}
           runs_older_than: ${{ github.event.inputs.runs_older_than || env.SCHEDULED_RUNS_OLDER_THAN }}
           runs_to_keep: ${{ github.event.inputs.runs_to_keep || env.SCHEDULED_RUNS_TO_KEEP }}
 


### PR DESCRIPTION
### Problem

The scheduled **Maintenance: Clean workflow logs** job fails:

```
[Invalid Parameter] <token> must be a valid GitHub token (ghp_, ghs_, or github_pat_)
```

([failing run](https://github.com/armbian/armbian.github.io/actions/runs/27996950747))

### Cause

The step passes no `token` input, relying on `igorjs/gh-actions-clean-workflow@v7`'s own `default: ${{ github.token }}`. On our **self-hosted `Linux` runner** that action-level default isn't substituted, so the action receives an empty value and fails its token-format validation. It's the only token-using step in the repo that *doesn't* pass the token explicitly.

### Fix

Pass `token: ${{ secrets.GITHUB_TOKEN }}` from the workflow context — evaluated in the workflow (not the action default), it resolves to the valid `ghs_…` runner token. This matches the convention already used by `generate-motd`, `repository-status`, `data-update-base-files-info`, and others. The job already declares `permissions: actions: write`, which is what the cleanup needs.