### PR TITLE
reporting-release-summary: use z.ai (GLM) instead of Anthropic

### DIFF
--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -41,7 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Use z.ai's Anthropic-compatible endpoint (GLM models) instead of the
+      # Anthropic API. The anthropic SDK reads both of these from the env.
+      ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
+      ANTHROPIC_API_KEY: ${{ secrets.ZAI_API_KEY }}
       SCOPE: ${{ inputs.scope || 'org:armbian' }}
       TZ: ${{ inputs.tz || 'Europe/Ljubljana' }}
       PERIOD: ${{ inputs.period || 'weekly' }}
@@ -216,10 +219,9 @@ jobs:
           with open("summary.md", "r", encoding="utf-8") as f:
               content = f.read().strip()
 
-          # Reads ANTHROPIC_API_KEY from the env. claude-opus-4-7 doesn't accept
-          # temperature/top_p/top_k (those 400 on this model). Adaptive thinking
-          # is enabled so Claude plans the thematic structure before drafting —
-          # noticeably better narrative flow than a one-shot completion.
+          # z.ai's Anthropic-compatible endpoint (ANTHROPIC_BASE_URL) serving a
+          # GLM model, authenticated with the z.ai key in ANTHROPIC_API_KEY —
+          # both picked up from the env by the SDK.
           client = Anthropic()
 
           system = (
@@ -265,9 +267,8 @@ jobs:
           )
 
           resp = client.messages.create(
-              model="claude-opus-4-7",
+              model="glm-4.6",
               max_tokens=4096,
-              thinking={"type": "adaptive"},
               system=system,
               messages=[{"role": "user", "content": prompt}],
           )


### PR DESCRIPTION
## Problem
The **Get PR's** job (`reporting-release-summary.yml`) failed at the *Write a short journalistic intro with AI* step:

```
anthropic.BadRequestError: Error code: 400 - Your credit balance is too low to access the Anthropic API.
```

## Fix
Point the AI step at **z.ai's Anthropic-compatible endpoint** (GLM models), using the `ZAI_API_KEY` secret — the `anthropic` SDK reads both values from the env, so `Anthropic()` needs no code change:

```yaml
ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
ANTHROPIC_API_KEY: ${{ secrets.ZAI_API_KEY }}
```

- `model` `claude-opus-4-7` → **`glm-4.6`**
- dropped `thinking={"type": "adaptive"}` — that's a Claude-specific param and would 400 on GLM

## Notes
- Auth uses the standard Anthropic `x-api-key` header (SDK default with `api_key`); z.ai's endpoint accepts it. If a run comes back **401**, the alternative is Bearer auth (`Anthropic(auth_token=...)`), a one-line change.
- Only the release-summary intro is switched. The Gemini cover-image step is unrelated and untouched.
- `scripts/generate_kernel_descriptions.py` also uses the Anthropic API (`claude-3-5-haiku`); if that runs somewhere and hits the same credit issue, I can point it at z.ai the same way — say the word.

Best validated by a manual `workflow_dispatch` run once merged (needs the secret).