### PR TITLE
generate-build-lists: only gate manual runs on team membership

### DIFF
--- a/.github/workflows/generate-build-lists.yaml
+++ b/.github/workflows/generate-build-lists.yaml
@@ -62,7 +62,12 @@ jobs:
     if: ${{ github.repository_owner == 'Armbian' }}
     steps:
 
+      # Only gate MANUAL runs on team membership. repository_dispatch is fired by
+      # a trusted Armbian workflow (actor = github-actions[bot], which team-check
+      # can't resolve as a user) and push already requires write access — neither
+      # should hit the human-authorization gate.
       - name: "Check membership"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: armbian/actions/team-check@main
         with:
           ORG_MEMBERS: ${{ secrets.ORG_MEMBERS }}


### PR DESCRIPTION
## Problem
[Run 28452472312](https://github.com/armbian/armbian.github.io/actions/runs/28452472312) (**Infrastructure: Generate image build lists**) failed at the **Check permissions → Check membership** step:

```
Could not resolve to a User with the login of 'github-actions[bot]'.
```

The run was triggered via **`repository_dispatch`** (fired by the image-info update workflow), so `github.actor` is `github-actions[bot]`. The `armbian/actions/team-check` action tries to resolve that as a real GitHub user to check "Release manager" membership — a bot has no user record, so the lookup errors and the whole run fails. The `generate` job (`needs: Check`) never runs.

## Fix
Gate the membership check on **`workflow_dispatch` only**:

```yaml
- name: "Check membership"
  if: ${{ github.event_name == 'workflow_dispatch' }}
  uses: armbian/actions/team-check@main
```

- **workflow_dispatch** (a human manually triggering) still requires "Release manager" — unchanged.
- **repository_dispatch** is fired by a trusted Armbian workflow (and can't be resolved anyway) → skips the gate; the Check job passes so `generate` runs.
- **push** to `release-targets/**` / `scripts/generate_targets.py` already requires write access → also skips the human gate.

The `Check` job still runs on every trigger (its `if: repository_owner == 'Armbian'` guard is intact); only the membership *step* is conditional, so `needs: Check` remains satisfied.