### PR TITLE
release-targets: add radxa-dragon-q8b with ufs extension

### DIFF
--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -20,6 +20,7 @@ minimal-stable-debian-uefi:
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
+    - { BOARD: radxa-dragon-q8b, BRANCH: vendor, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
 # Ubuntu minimal with current kernel - UEFI only
@@ -45,6 +46,7 @@ minimal-stable-ubuntu-current-uefi:
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
+    - { BOARD: radxa-dragon-q8b, BRANCH: vendor, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
 # Ubuntu minimal with current kernel - UEFI only - noble (LTS)
@@ -88,6 +90,7 @@ desktop-stable-ubuntu-gnome-uefi:
     - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
     - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
+    - { BOARD: radxa-dragon-q8b, BRANCH: vendor, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
 # Ubuntu Cinnamon desktop - UEFI only
@@ -110,6 +113,7 @@ desktop-stable-ubuntu-cinnamon-uefi:
     - { BOARD: uefi-x86, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms,nvidia" }
     - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
     - { BOARD: radxa-dragon-q6a, BRANCH: current, ENABLE_EXTENSIONS: "ufs" }
+    - { BOARD: radxa-dragon-q8b, BRANCH: vendor, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
 # Ubuntu KDE Plasma desktop - UEFI only


### PR DESCRIPTION
The Radxa Dragon Q8B (BOARDFAMILY sc8280xp, KERNEL_TARGET=vendor) can run from a UFS module, alongside microSD and NVMe.

This enables the ufs extension for q8b (BRANCH: vendor) in the same four standard-support blocks that already carry radxa-dragon-q6a and radxa-nio-12l: Debian minimal, Ubuntu current minimal, Ubuntu GNOME and Ubuntu Cinnamon.

It only adds the -ufs image variant, the regular microSD image is unaffected. The board image itself is already in the repo from the earlier board-image commit.
