### PR TITLE
release-targets: drop deprecated DESKTOP_ENVIRONMENT_CONFIG_NAME / DESKTOP_APPGROUPS_SELECTED

### DIFF
--- a/release-targets/README.md
+++ b/release-targets/README.md
@@ -117,8 +117,6 @@ desktop-stable-ubuntu-cinnamon:
     BUILD_MINIMAL: "no"
     BUILD_DESKTOP: "yes"
     DESKTOP_ENVIRONMENT: "cinnamon"
-    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-    DESKTOP_APPGROUPS_SELECTED: ""
     DESKTOP_TIER: "mid"             # required for desktop blocks; armbian-config picks
                                     # minimal / mid / full from this when assembling
                                     # the rootfs

--- a/release-targets/targets-release-community-maintained.manual
+++ b/release-targets/targets-release-community-maintained.manual
@@ -43,8 +43,6 @@ desktop-stable-debian-xfce:
     BUILD_MINIMAL: "no"
     BUILD_DESKTOP: "yes"
     DESKTOP_ENVIRONMENT: "xfce"
-    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-    DESKTOP_APPGROUPS_SELECTED: ""
     DESKTOP_TIER: "mid"
   items:
     - { BOARD: aml-s9xx-box, BRANCH: current }

--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -82,8 +82,6 @@ desktop-stable-ubuntu-gnome-uefi:
     BUILD_MINIMAL: "no"
     BUILD_DESKTOP: "yes"
     DESKTOP_ENVIRONMENT: "gnome"
-    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
     - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
@@ -105,8 +103,6 @@ desktop-stable-ubuntu-cinnamon-uefi:
     BUILD_MINIMAL: "no"
     BUILD_DESKTOP: "yes"
     DESKTOP_ENVIRONMENT: "cinnamon"
-    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
     - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
@@ -128,8 +124,6 @@ desktop-stable-ubuntu-kde-plasma-uefi:
     BUILD_MINIMAL: "no"
     BUILD_DESKTOP: "yes"
     DESKTOP_ENVIRONMENT: "kde-plasma"
-    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
     - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
@@ -147,8 +141,6 @@ desktop-stable-ubuntu-mate-uefi:
     BUILD_MINIMAL: "no"
     BUILD_DESKTOP: "yes"
     DESKTOP_ENVIRONMENT: "mate"
-    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
     - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
@@ -166,8 +158,6 @@ desktop-stable-ubuntu-xfce-uefi:
     BUILD_MINIMAL: "no"
     BUILD_DESKTOP: "yes"
     DESKTOP_ENVIRONMENT: "xfce"
-    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
     - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }
@@ -185,8 +175,6 @@ desktop-stable-ubuntu-i3-wm-uefi:
     BUILD_MINIMAL: "no"
     BUILD_DESKTOP: "yes"
     DESKTOP_ENVIRONMENT: "i3-wm"
-    DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-    DESKTOP_APPGROUPS_SELECTED: "browsers,programming"
     DESKTOP_TIER: "mid"
   items:
     - { BOARD: uefi-arm64, BRANCH: edge, ENABLE_EXTENSIONS: "v4l2loopback-dkms" }

--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -1148,8 +1148,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: "programming"
       DESKTOP_TIER: "mid"
     items:
       - *stable-current-slow-hdmi
@@ -1174,8 +1172,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "gnome"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: "programming"
       DESKTOP_TIER: "mid"
     items:
 """
@@ -1209,8 +1205,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "kde-plasma"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: "programming"
       DESKTOP_TIER: "mid"
     items:
       - *stable-current-fast-hdmi
@@ -1235,8 +1229,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: "programming"
       DESKTOP_TIER: "mid"
     items:
       - *stable-legacy-fast-hdmi
@@ -1257,8 +1249,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"
     items:
 """
@@ -1292,8 +1282,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "bianbu"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "mid"
     items:
       - *stable-legacy-riscv64
@@ -1460,8 +1448,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "gnome"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"
     items:
       - *nightly-fast-hdmi
@@ -1482,8 +1468,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"
     items:
       - *nightly-slow-hdmi
@@ -1504,8 +1488,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"
     items:
       - *nightly-riscv64
@@ -1746,8 +1728,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "gnome"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"
     items:
       - *community-current-fast-hdmi
@@ -1775,8 +1755,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "kde-plasma"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"
     items:
       - *community-current-fast-hdmi
@@ -1801,8 +1779,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"
     items:
 """
@@ -1828,8 +1804,6 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: ""
       DESKTOP_TIER: "minimal"
     items:
 """


### PR DESCRIPTION
Both `DESKTOP_ENVIRONMENT_CONFIG_NAME` and `DESKTOP_APPGROUPS_SELECTED` are deprecated switches that the build framework no longer consumes. Removed them from every place they were emitted:

- **`scripts/generate_targets.py`** — 13 desktop stanzas (26 lines)
- **`release-targets/targets-release-standard-support.manual`** — 6 blocks (12 lines)
- **`release-targets/targets-release-community-maintained.manual`** — 1 block (2 lines)
- **`release-targets/README.md`** — the documented example

No other vars change — `DESKTOP_ENVIRONMENT` + `DESKTOP_TIER` continue to drive desktop selection.

Verified: `generate_targets.py` still `py_compile`s; every removed line is one of the two switches (git diff shows 40 deletions, 0 collateral); the `vars:` blocks remain well-formed; no references remain anywhere under `scripts/` or `release-targets/`.