### PR TITLE
generate_targets: build rootfs-riscv64 on the native ubuntu-24.04-riscv runner

### DIFF
--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -730,7 +730,7 @@ armbian-gha: &armbian-gha
       rootfs-armhf: [ "ubuntu-latest" ]
       rootfs-arm64: [ "ubuntu-24.04-arm" ]
       rootfs-amd64: [ "self-hosted", "Linux", "X64" ]
-      rootfs-riscv64: [ "ubuntu-latest" ]
+      rootfs-riscv64: [ "ubuntu-24.04-riscv" ]
       rootfs-loong64: [ "self-hosted", "Linux", "X64" ]
       image-armhf: [ "self-hosted", "Linux", 'images', 'X64' ]
       image-arm64: [ "self-hosted", "Linux", 'images', 'ARM64' ]


### PR DESCRIPTION
`rootfs-riscv64` was assigned `ubuntu-latest` (x86) in the shared `armbian-gha` runner map, so the riscv64 rootfs was built under **qemu-user emulation**.

Point it at the native **`ubuntu-24.04-riscv`** runner instead — mirroring `rootfs-arm64: ubuntu-24.04-arm` — so every riscv64 rootfs builds natively.

- Single source of truth: the `armbian-gha` anchor is referenced by every target via `gha: *armbian-gha`, so this applies to all riscv64 rootfs builds (standard / nightly / community / apps). Confirmed it is the only `rootfs-riscv64` runner assignment in the repo.
- Image assembly (`image-riscv64`) is unchanged (stays on the self-hosted X64 image runner).
- `py_compile` clean.