### PR TITLE
release-targets: blacklist sk-am62-lp from stable builds

### DIFF
--- a/release-targets/targets-release-standard-support.blacklist
+++ b/release-targets/targets-release-standard-support.blacklist
@@ -1,0 +1,3 @@
+# Boards excluded from standard-support (stable) release builds.
+# One board name per line; '#' comments and blank lines are ignored.
+sk-am62-lp


### PR DESCRIPTION
Excludes `sk-am62-lp` from **standard-support (stable)** release image generation.

Adds a new `release-targets/targets-release-standard-support.blacklist`:
```
sk-am62-lp
```

`scripts/generate_targets.py` loads it via `load_blacklist()` into `blacklist_stable` (line ~2172) for `targets-release-standard-support.yaml`, so the board is dropped from the stable matrix on the next generation.

Notes:
- The board is **already** blacklisted from nightly (`targets-release-nightly.blacklist`); this extends the exclusion to stable.
- Not re-added by any `.manual` input.
- Comment/blank lines are ignored by the parser, so the header is safe.