### PR TITLE
scripts: source nightly images from armbian/ci releases (moved from os)

### DIFF
--- a/.github/workflows/infrastructure-mirror-repository-artifacts.yml
+++ b/.github/workflows/infrastructure-mirror-repository-artifacts.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PULL_REPOSITORY: "${{ github.event.client_payload.pull_repository || 'cli/cli' }}" # username/repository
+  PULL_REPOSITORY: "${{ github.event.client_payload.pull_repository || 'armbian/ci' }}" # username/repository
   CDN_TAG: "${{ github.event.client_payload.cdn_tag || 'os' }}" # folder on server
   PULL_TAG: "" # leave empty for latest
 

--- a/.github/workflows/infrastructure-mirror-repository-artifacts.yml
+++ b/.github/workflows/infrastructure-mirror-repository-artifacts.yml
@@ -8,7 +8,7 @@ on:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULL_REPOSITORY: "${{ github.event.client_payload.pull_repository || 'armbian/ci' }}" # username/repository
-  CDN_TAG: "${{ github.event.client_payload.cdn_tag || 'os' }}" # folder on server
+  CDN_TAG: "${{ github.event.client_payload.cdn_tag || 'ci' }}" # folder on server
   PULL_TAG: "" # leave empty for latest
 
 jobs:

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -180,28 +180,32 @@ jobs:
           path: out/
           if-no-files-found: warn
 
-      - name: "Checkout OS repository to get version"
-        uses: actions/checkout@v7
-        with:
-          repository: armbian/os
-          fetch-depth: 0
-          clean: false
-          path: os
-
-      - name: "Read version from nightly or stable based on period"
+      - name: "Read version from armbian/ci tags (nightly = latest *trunk* tag, else stable)"
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$PERIOD" == "monthly" || "$PERIOD" == "quarterly" ]]; then
-            FILE="os/stable.json"
-          else
-            FILE="os/nightly.json"
-          fi
-          if [[ ! -f "$FILE" ]]; then
-            echo "::error file=$FILE::Version file not found"
+          # Nightly images now release under armbian/ci, so derive the version
+          # from its tags instead of the old os/{nightly,stable}.json files:
+          # the newest tag with 'trunk' in the name is the nightly version, the
+          # newest without it is stable. -v:refname yields version order, so
+          # 26.8.0-trunk.6 > 26.8.0-trunk.5 and 26.8.0 > its prereleases.
+          TAGS=$(git ls-remote --tags --refs --sort=-v:refname \
+            https://github.com/armbian/ci | sed 's#.*refs/tags/##')
+          if [[ -z "$TAGS" ]]; then
+            echo "::error::No tags found in armbian/ci"
             exit 1
           fi
-          VERSION=$(jq -r '.version' "$FILE")
+          if [[ "$PERIOD" == "monthly" || "$PERIOD" == "quarterly" ]]; then
+            VERSION=$(grep -v -- trunk <<<"$TAGS" | head -n1 || true)   # stable
+          else
+            VERSION=$(grep -- trunk <<<"$TAGS" | head -n1 || true)      # nightly
+          fi
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::No matching armbian/ci tag for period=$PERIOD"
+            exit 1
+          fi
+          VERSION="${VERSION#v}"   # downstream re-adds the 'v' prefix
+          echo "Selected ${PERIOD} version from armbian/ci tags: ${VERSION}"
           echo "VERSION_OVERRIDE=${VERSION}" >> "$GITHUB_ENV"
 
       - name: "Write a short journalistic intro with AI"

--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -612,8 +612,11 @@ awk '
 }' >"$tmpdir/a.txt"
 
 # GitHub feed
+# community  -> community images
+# ci         -> nightly (trunk) images   (moved here from armbian/os)
+# distribution -> stable release images
 : >"$tmpdir/bcd.txt"
-for repo in community os distribution; do
+for repo in community ci distribution; do
   gh release view --json assets --repo "github.com/armbian/$repo" |
   jq -r '.assets[]
     | select(.url | test("\\.txt($|\\?)") | not)
@@ -664,7 +667,9 @@ cat "$tmpdir/a.txt" "$tmpdir/bcd.txt" >"$feed"
     REPO="$(get_download_repository "$URL")"
     [[ -z "$REPO" ]] && continue
 
-    PREFIX=""; [[ "$REPO" == "os" ]] && PREFIX="nightly/"
+    # Nightly (trunk) images now release under armbian/ci (moved from armbian/os);
+    # they are served under the dl.armbian.com nightly/ path.
+    PREFIX=""; [[ "$REPO" == "ci" ]] && PREFIX="nightly/"
 
     BASE_EXT="$(extract_file_extension "$IMAGE_NAME")"
     if [[ -n "$STORAGE" ]]; then
@@ -718,7 +723,7 @@ cat "$tmpdir/a.txt" "$tmpdir/bcd.txt" >"$feed"
 
     REDI_URL="https://dl.armbian.com/${PREFIX}${BOARD_SLUG}/${DISTRO^}_${REDI_BRANCH}_${REDI_VARIANT}"
 
-    # file_url must remain the original URL (GitHub Releases for community/os/distribution)
+    # file_url must remain the original URL (GitHub Releases for community/ci/distribution)
     FILE_URL="$URL"
 
     if [[ "$URL" == https://github.com/armbian/* ]]; then

--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -1979,7 +1979,7 @@ def generate_exposed_map(
 
         # Pattern format: Armbian_[0-9].*BoardName_Release_Branch_[0-9]*.[0-9]*.[0-9]*_Type.ext
         # Community images have 'community_' prefix, stable images don't
-        # This excludes nightly images (which come from armbian/os repo without 'community_' prefix)
+        # This excludes nightly images (which come from armbian/ci repo without 'community_' prefix)
         community_prefix = '(community_)?' if board_type == 'community' else ''
         # Capitalize board name for pattern
         board_pattern = capitalize_board_name(board)


### PR DESCRIPTION
## What

Nightly (trunk) images now publish to GitHub **releases under `armbian/ci`** instead of `armbian/os`. This moves the consuming scripts to the new location.

## Changes

**`scripts/generate-armbian-images-json.sh`**
- GitHub release feed loop: `community os distribution` → **`community ci distribution`** (~line 616). `os` hosted only the nightly images, so it's replaced by `ci`.
- `nightly/` dl-path prefix now keys on `REPO == "ci"` (~line 667). `get_download_repository()` derives the repo from the asset URL, so nightly images at `github.com/armbian/ci/releases/...` resolve to `ci` and keep the `dl.armbian.com/nightly/<board>/...` REDI layout.
- refreshed the two stale `os` comments.

**`scripts/generate_targets.py`** — refreshed the stale `armbian/os` comment.

**`.github/workflows/reporting-release-summary.yml`** — the release-summary version no longer reads `os/{nightly,stable}.json`. It now pulls **tags from `armbian/ci`** and selects by period: the newest tag with `trunk` in its name is the nightly version, the newest without it is stable (`git ls-remote --sort=-v:refname` for version ordering). Drops the `armbian/os` checkout. `VERSION_OVERRIDE` stays a bare version — both consumers (`cover.png` URL, release `tag:`) re-add the `v`.

## ⚠️ One thing to confirm

The emitted **`download_repository`** column is now **`ci`** for nightly rows (was `os`). If the public download portal categorizes "nightly vs stable" off this field's `os` value, I can remap it — nothing in this repo depends on it.

## Still not touched

`.github/workflows/data-update-download-index.yml` still checks out `armbian/os`. If the version metadata it reads has also moved, say so and I'll update that checkout too.