### PR TITLE
release-targets: live ISO for the cloud UEFI images (uefi-x86 + uefi-arm64)

### DIFF
--- a/release-targets/targets-release-nightly.manual
+++ b/release-targets/targets-release-nightly.manual
@@ -13,6 +13,8 @@ minimal-cli-stable-ubuntu-cloud:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -30,6 +32,8 @@ minimal-cli-unstable-debian-cloud:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -51,6 +55,8 @@ minimal-cli-stable-debian-cloud-trixie:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -71,6 +77,8 @@ minimal-cli-stable-ubuntu-cloud-noble:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }

--- a/release-targets/targets-release-nightly.manual
+++ b/release-targets/targets-release-nightly.manual
@@ -13,8 +13,8 @@ minimal-cli-stable-ubuntu-cloud:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
-    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
-    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -32,8 +32,8 @@ minimal-cli-unstable-debian-cloud:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
-    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
-    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -55,8 +55,8 @@ minimal-cli-stable-debian-cloud-trixie:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
-    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
-    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -77,8 +77,8 @@ minimal-cli-stable-ubuntu-cloud-noble:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
-    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
-    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }

--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -39,8 +39,8 @@ minimal-stable-ubuntu-current-uefi:
     - { BOARD: uefi-x86, BRANCH: edge }
     - { BOARD: uefi-arm64, BRANCH: current }
     - { BOARD: uefi-x86, BRANCH: current }
-    - { BOARD: uefi-arm64, BRANCH: cloud }
-    - { BOARD: uefi-x86, BRANCH: cloud }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -63,8 +63,8 @@ minimal-stable-ubuntu-noble-current-uefi:
   items:
     - { BOARD: uefi-arm64, BRANCH: current }
     - { BOARD: uefi-x86, BRANCH: current }
-    - { BOARD: uefi-arm64, BRANCH: cloud }
-    - { BOARD: uefi-x86, BRANCH: cloud }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }

--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -39,8 +39,8 @@ minimal-stable-ubuntu-current-uefi:
     - { BOARD: uefi-x86, BRANCH: edge }
     - { BOARD: uefi-arm64, BRANCH: current }
     - { BOARD: uefi-x86, BRANCH: current }
-    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
-    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
@@ -63,8 +63,8 @@ minimal-stable-ubuntu-noble-current-uefi:
   items:
     - { BOARD: uefi-arm64, BRANCH: current }
     - { BOARD: uefi-x86, BRANCH: current }
-    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
-    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "uefi-iso" }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }


### PR DESCRIPTION
Enables the **image-output-iso** extension on the **cloud** `uefi-x86` and `uefi-arm64` UEFI targets, so those cloud images ship as a bootable **live ISO** for BMC/IPMI virtual-CD install. Boot the live system, then install to disk with `armbian-install`.

- **`targets-release-standard-support.manual`** — cloud `uefi-arm64` + `uefi-x86` on Ubuntu current & noble.
- **`targets-release-nightly.manual`** — cloud `uefi-arm64` + `uefi-x86` on each nightly cloud target.
- qcow2 / vhdx unchanged. Debian standard-support has no plain cloud item, so nothing was converted there.

### ⚠️ Blocked — draft until:
1. **armbian/build#10314** (the `image-output-iso` extension) is merged.
2. **arm64** is validated on real UEFI/BMC hardware (amd64 is validated; arm64 not yet booted).