### PR TITLE
release: build UEFI cloud ISO for Debian stable (trixie) minimal

### DIFF
--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -15,6 +15,8 @@ minimal-stable-debian-uefi:
   items:
     - { BOARD: uefi-arm64, BRANCH: edge }
     - { BOARD: uefi-x86, BRANCH: edge }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }


### PR DESCRIPTION
## What

Adds the `image-output-iso` cloud outputs (arm64 + x86) to the **`minimal-stable-debian-uefi`** target (Debian stable = trixie, minimal) in `release-targets/targets-release-standard-support.manual`.

```diff
     - { BOARD: uefi-arm64, BRANCH: edge }
     - { BOARD: uefi-x86, BRANCH: edge }
+    - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
+    - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-iso" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
```

## Why

Stable already builds cloud **qcow2** and **vhdx** for these UEFI targets but not **iso**, while the nightly target (`minimal-cli-stable-debian-cloud-trixie`) already ships the iso pair. This brings stable in line. Placed before the qcow2 pair so the cloud outputs read iso → qcow2 → vhdx, matching the nightly target's ordering.