### PR TITLE
build-lists: rename apps extensions (applications-*) and drop openHAB

### DIFF
--- a/.github/workflows/generate-build-lists.yaml
+++ b/.github/workflows/generate-build-lists.yaml
@@ -33,7 +33,7 @@ on:
         required: false
         default: "resolute"
       debian_apps:
-        description: "Debian codename for apps builds (HA / OMV / OpenHAB; not Kali, which stays sid)"
+        description: "Debian codename for apps builds (HA / OMV; not Kali, which stays sid)"
         required: false
         default: "trixie"
       ubuntu_apps:

--- a/release-targets/README.md
+++ b/release-targets/README.md
@@ -32,7 +32,7 @@ Five files written to the output directory.
 
 | File | What it drives |
 |---|---|
-| `targets-release-apps.yaml` | Application-specific images (Home Assistant, openHAB, Kali). |
+| `targets-release-apps.yaml` | Application-specific images (Home Assistant, OMV, Kali). |
 | `targets-release-standard-support.yaml` | Standard-support release images for `conf` / `wip` boards, split by performance class and branch. |
 | `targets-release-nightly.yaml` | Nightly builds for `conf` / `wip` boards. |
 | `targets-release-community-maintained.yaml` | Community / experimental builds for `csc` / `tvb` boards. |
@@ -46,7 +46,7 @@ Targets are emitted only for combinations that have at least one board:
 
 - `minimal-…` — Debian or Ubuntu CLI image, per branch (current / vendor / legacy / edge), per architecture class (default / riscv64 / loongarch).
 - `desktop-…` — Ubuntu desktop image, per `DESKTOP_ENVIRONMENT` (xfce / gnome / bianbu) the matrix supports for that release × arch combo. Fast HDMI boards get GNOME; slow / riscv64 get XFCE; the SpacemiT K1 family on the legacy branch gets the Bianbu desktop.
-- `apps-…` — Home Assistant + openHAB on Ubuntu (the `apps` scope tracks the last LTS for build-image stability), Kali on `sid`.
+- `apps-…` — Home Assistant + OMV on Ubuntu (the `apps` scope tracks the last LTS for build-image stability), Kali on `sid`.
 
 The exact codename each `RELEASE:` line resolves to depends on which `--<distro>-<scope>` flags the workflow was dispatched with — see [Per-scope codename flags](#per-scope-codename-flags).
 

--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -345,7 +345,7 @@ fi
 is_version_token() { [[ "$1" =~ ^[0-9]{2}\.[0-9] ]]; }
 
 is_preinstalled_app() {
-  case "$1" in kali|homeassistant|openhab|omv) return 0 ;; *) return 1 ;; esac
+  case "$1" in kali|homeassistant|omv) return 0 ;; *) return 1 ;; esac
 }
 
 split_desktop_tail() {
@@ -605,7 +605,7 @@ awk '
   if (url ~ /\/[^\/]+\/archive\/Armbian/ &&
       url !~ /\.txt$/ &&
       url !~ /\.(asc|sha|torrent)$/ &&
-      url !~ /(homeassistant|openhab|kali|omv)/) {
+      url !~ /(homeassistant|kali|omv)/) {
     dt=$3 "T" $4 "Z"; gsub("/", "-", dt)
     print size "|" url "|" dt
   }

--- a/scripts/generate-rpi-imager-json.py
+++ b/scripts/generate-rpi-imager-json.py
@@ -39,7 +39,7 @@ class RpiImagerGenerator:
 
     # Exclude patterns
     EXCLUDE_PATTERNS = [
-        "homeassistant", "openhab", "kali", "omv", "trunk"
+        "homeassistant", "kali", "omv", "trunk"
     ]
 
     # Only include these file extensions

--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -792,7 +792,7 @@ targets:
       RELEASE: DEBIAN
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "no"
-      ENABLE_EXTENSIONS: "ha"
+      ENABLE_EXTENSIONS: "applications-ha"
     items:
       - *apps-builds
 
@@ -806,7 +806,7 @@ targets:
       RELEASE: DEBIAN
       BUILD_MINIMAL: "yes"
       BUILD_DESKTOP: "no"
-      ENABLE_EXTENSIONS: "omv"
+      ENABLE_EXTENSIONS: "applications-omv"
     items:
       - *apps-builds
 
@@ -834,7 +834,7 @@ targets:
       RELEASE: sid
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "no"
-      ENABLE_EXTENSIONS: "kali"
+      ENABLE_EXTENSIONS: "applications-kali"
     items:
       - *apps-builds
 """

--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -810,20 +810,6 @@ targets:
     items:
       - *apps-builds
 
-  apps-openhab:
-    enabled: yes
-    configs: [ armbian-apps ]
-    pipeline:
-      gha: *armbian-gha
-    build-image: "yes"
-    vars:
-      RELEASE: DEBIAN
-      BUILD_MINIMAL: "no"
-      BUILD_DESKTOP: "no"
-      ENABLE_EXTENSIONS: "openhab"
-    items:
-      - *apps-builds
-
   apps-kali:
     enabled: yes
     configs: [ armbian-apps ]

--- a/scripts/report-download-images.py
+++ b/scripts/report-download-images.py
@@ -10,7 +10,7 @@
 #   archive       -> the per-board DOWNLOAD on dl.armbian.com/<board>/archive/
 #                    (all released versions per board). THIS is "the download".
 #   distribution  -> appliance images on github.com/armbian/distribution
-#                    (kali / omv / homeassistant / openhab), a separate product.
+#                    (kali / omv / homeassistant), a separate product.
 #   community     -> community nightly (github.com/armbian/os or community).
 #   ci            -> CI nightly (github.com/armbian/ci).
 #
@@ -40,7 +40,7 @@ DOWNLOAD_REPO = "archive"
 # human labels for the overview (also documents what each channel really is)
 REPO_LABELS = {
     "archive": "Download (dl.armbian.com, per-board releases)",
-    "distribution": "Appliance images (kali/omv/homeassistant/openhab)",
+    "distribution": "Appliance images (kali/omv/homeassistant)",
     "community": "Community nightly",
     "ci": "CI nightly",
     "": "(orphaned — no repo)",


### PR DESCRIPTION
Follows the armbian/build rename of the app build extensions to an `applications-` prefix (`docker-ce`, `applications-{ha,kali,omv}`).

## Rename apps `ENABLE_EXTENSIONS`
In `generate_targets.py`'s apps emit:

| target | before | after |
| --- | --- | --- |
| `apps-ha` | `ha` | `applications-ha` |
| `apps-omv` | `omv` | `applications-omv` |
| `apps-kali` | `kali` | `applications-kali` |

The `apps-*` target keys and the `-homeassistant` / `-omv` / `-kali` image suffixes are unchanged, so downstream image categorization keeps matching.

## Drop openHAB
openHAB will no longer be built, so it's removed end-to-end:
- `apps-openhab` target removed from the apps YAML emit.
- Dropped from `generate-armbian-images-json.sh` (app matcher + exclude regex), `generate-rpi-imager-json.py` (exclude list), `report-download-images.py` (labels/comment), the `generate-build-lists.yaml` input description, and the `release-targets/README.md`.

`py_compile` / `bash -n` clean; no `openhab` references remain in `scripts/`, `release-targets/`, or `.github/workflows/`.