### PR TITLE
readme-updater: include armbian/distribution

### DIFF
--- a/.github/workflows/maintenance-update-readme.yml
+++ b/.github/workflows/maintenance-update-readme.yml
@@ -22,7 +22,7 @@ on:
       repos:
         description: "Comma-separated owner/repo targets (default: core repos)"
         required: false
-        default: "armbian/build,armbian/configng,armbian/ci,armbian/imager,armbian/documentation"
+        default: "armbian/build,armbian/configng,armbian/ci,armbian/imager,armbian/documentation,armbian/distribution"
       model:
         description: "Claude model id"
         required: false
@@ -47,7 +47,7 @@ jobs:
       - id: set
         env:
           # Route the dispatch input through env (not inline ${{ }}) to avoid shell injection.
-          REPOS: ${{ github.event.inputs.repos || 'armbian/build,armbian/configng,armbian/ci,armbian/imager,armbian/documentation' }}
+          REPOS: ${{ github.event.inputs.repos || 'armbian/build,armbian/configng,armbian/ci,armbian/imager,armbian/documentation,armbian/distribution' }}
         run: |
           set -euo pipefail
           matrix="$(echo "$REPOS" | tr ',' '\n' | sed 's/[[:space:]]//g' | grep -v '^$' | jq -R . | jq -s -c .)"


### PR DESCRIPTION
Add `armbian/distribution` to the **Maintenance: Update README (AI)** target list so its README is refreshed alongside the other core repos.

Updated in both places that carry the default list: the `workflow_dispatch` input default (line 25) and the schedule fallback used when the input is empty (line 50). YAML validated.