### PR TITLE
generate-armbian-images-json: support UEFI cloud .iso artifacts

### DIFF
--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -367,7 +367,7 @@ split_desktop_tail() {
 }
 
 strip_img_ext() {
-  sed -E 's/(\.img(\.(xz|zst|gz))?|\.tar\.(xz|zst|gz))$//' <<<"$1"
+  sed -E 's/(\.img(\.(xz|zst|gz))?|\.iso|\.tar\.(xz|zst|gz))$//' <<<"$1"
 }
 
 extract_file_extension() {
@@ -465,6 +465,12 @@ extract_file_extension() {
   fi
   if [[ "$n" == *.hyperv.zip ]]; then
     echo "hyperv.zip"
+    return
+  fi
+
+  # live ISO images (UEFI cloud): shipped uncompressed -> iso
+  if [[ "$n" == *.iso ]]; then
+    echo "iso"
     return
   fi
 
@@ -708,6 +714,8 @@ cat "$tmpdir/a.txt" "$tmpdir/bcd.txt" >"$feed"
 
     if [[ "$FILE_EXTENSION" == img.qcow2* ]]; then
       REDI_VARIANT="${VARIANT}-qcow2"
+    elif [[ "$FILE_EXTENSION" == iso* ]]; then
+      REDI_VARIANT="${VARIANT}-iso"
     elif [[ "$FILE_EXTENSION" == hyperv.zip* ]]; then
       REDI_VARIANT="${VARIANT}-hyperv"
     elif [[ "$FILE_EXTENSION" == fip.img* ]]; then


### PR DESCRIPTION
## What

The UEFI cloud targets (`uefi-arm64` / `uefi-x86`, `BRANCH: cloud`) now publish a **live `.iso`** (uncompressed) alongside qcow2/vhdx. This teaches the download-index generator (`scripts/generate-armbian-images-json.sh`) to represent it correctly.

Three small additions:

1. **`extract_file_extension`** — map a plain `.iso` to the canonical `iso` extension (before this it fell through to the generic last-token fallback).
2. **`strip_img_ext`** — strip a trailing `.iso` so `parse_image_name` recovers the clean variant token (`minimal`) instead of `minimal.iso`.
3. **REDI variant** — give ISOs a distinct `-iso` variant, mirroring qcow2's `-qcow2`, so the redirector URL comes out as:

```
https://dl.armbian.com/uefi-arm64/Noble_cloud_minimal-iso
```

The release-asset filter already lets `.iso` through (it only drops `.txt/.asc/.sha/.torrent`), so no change needed there.

## Validation

Unit-tested the parsing/URL assembly:

| filename | file_extension | redi_url |
|---|---|---|
| `..._uefi-arm64_noble_cloud_..._minimal.iso` | `iso` | `.../uefi-arm64/Noble_cloud_minimal-iso` |

Regression-checked: `.img.qcow2.xz` → `img.qcow2.xz` and `.img.xz` → `img.xz` unchanged. `bash -n` clean.

Pairs with the build-side change that produces the ISO (`image-output-iso`) and the release-target additions that enable it for the trixie minimal UEFI cloud target.