### PR TITLE
generate-actions-report: scan ci repo instead of os

### DIFF
--- a/.github/workflows/generate-actions-report.yml
+++ b/.github/workflows/generate-actions-report.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        repo: ["armbian.github.io", "build", "imager", "os", "sdk", "documentation", "shallow", "docker-armbian-build", "configng"]
+        repo: ["armbian.github.io", "build", "imager", "ci", "sdk", "documentation", "shallow", "docker-armbian-build", "configng"]
       fail-fast: false
       max-parallel: 1 # free api is very limited
 


### PR DESCRIPTION
The **Infrastructure: Update Armbian automation status** report scans a fixed list of Armbian repos. Build pipelines moved from `armbian/os` to `armbian/ci`, so swap the matrix entry: add **`ci`**, drop **`os`**.

```diff
- repo: [..., "imager", "os", "sdk", ...]
+ repo: [..., "imager", "ci", "sdk", ...]
```