### PR TITLE
release: build uefi-loong64 only as Debian sid CLI minimal

### DIFF
--- a/release-targets/targets-release-standard-support.blacklist
+++ b/release-targets/targets-release-standard-support.blacklist
@@ -1,3 +1,7 @@
 # Boards excluded from standard-support (stable) release builds.
 # One board name per line; '#' comments and blank lines are ignored.
 sk-am62-lp
+# LoongArch only exists in Debian sid, so the stable auto-generated targets
+# can't build it. The one working combo (Debian sid CLI minimal) is added
+# manually in targets-release-standard-support.manual instead.
+uefi-loong64

--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -25,6 +25,23 @@ minimal-stable-debian-uefi:
     - { BOARD: radxa-dragon-q8b, BRANCH: vendor, ENABLE_EXTENSIONS: "ufs" }
     - { BOARD: radxa-nio-12l, BRANCH: edge, ENABLE_EXTENSIONS: "ufs" }
 
+# Debian sid minimal - loong64 UEFI only.
+# LoongArch has no Debian stable port (it lives in sid), so uefi-loong64 is
+# blacklisted from the stable auto-generated targets and its one buildable
+# image - Debian sid CLI minimal - is defined here explicitly.
+minimal-stable-debian-loong64-uefi:
+  enabled: yes
+  configs: [ armbian-images ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: sid
+    BUILD_MINIMAL: "yes"
+    BUILD_DESKTOP: "no"
+  items:
+    - { BOARD: uefi-loong64, BRANCH: edge }
+
 # Ubuntu minimal with current kernel - UEFI only
 minimal-stable-ubuntu-current-uefi:
   enabled: yes

--- a/release-targets/targets-release-standard-support.manual
+++ b/release-targets/targets-release-standard-support.manual
@@ -40,6 +40,7 @@ minimal-stable-debian-loong64-uefi:
     BUILD_MINIMAL: "yes"
     BUILD_DESKTOP: "no"
   items:
+    - { BOARD: uefi-loong64, BRANCH: current }
     - { BOARD: uefi-loong64, BRANCH: edge }
 
 # Ubuntu minimal with current kernel - UEFI only


### PR DESCRIPTION
`uefi-loong64` is a standard-support board, but **LoongArch has no Debian stable port** — it only exists in **Debian sid**. So the auto-generated stable standard-support targets try (and fail) to build it across the usual releases, and only **Debian sid CLI minimal** is actually buildable.

## Changes

- **`targets-release-standard-support.blacklist`** — add `uefi-loong64` so it's dropped from the auto-generated stable targets (same treatment it already has in `targets-release-apps.blacklist`).
- **`targets-release-standard-support.manual`** — add the one buildable combo explicitly:

```yaml
minimal-stable-debian-loong64-uefi:
  vars:
    RELEASE: sid
    BUILD_MINIMAL: "yes"
    BUILD_DESKTOP: "no"
  items:
    - { BOARD: uefi-loong64, BRANCH: edge }
```

Uses an explicit `RELEASE: sid` (like the existing `RELEASE: noble` target), not the `DEBIAN` meta which resolves to stable.

YAML validated (with the `*armbian-gha` anchor stubbed).