### PR TITLE
servers feed: expose cputhreads in github-runners.jq

### DIFF
--- a/.github/workflows/generate-servers-jsons.yml
+++ b/.github/workflows/generate-servers-jsons.yml
@@ -132,7 +132,8 @@ jobs:
                     apt_proxy: (.custom_fields["apt_proxy"] // ""),
                     oci_cache: (.custom_fields["oci_cache"] // ""),
                     redis_cache: (.custom_fields["redis_cache"] // ""),
-                    git_proxy: (.custom_fields["git_proxy"] // "")
+                    git_proxy: (.custom_fields["git_proxy"] // ""),
+                    cputhreads: (.custom_fields["cputhreads"] // "")
                   }
               )
             | sort_by(.host)


### PR DESCRIPTION
Emit the NetBox VM custom field **`cputhreads`** in the `github-runners.jq` runner feed, next to `apt_proxy` / `oci_cache` / `redis_cache` / `git_proxy`.

`runner-clean/action.yml` (armbian/actions#37) reads this to export `CPUTHREADS` and cap the build's `make -j` per runner — so several runners on one big host don't oversubscribe cores. Defaults to `""` when the field is unset (no cap).

This is the feed half of the wiring; the field already exists on the VMs in NetBox (integer, no group).