### PR TITLE
partners: expose company_slug in partners.json

### DIFF
--- a/.github/workflows/data-update-partners-data.yml
+++ b/.github/workflows/data-update-partners-data.yml
@@ -64,6 +64,7 @@ jobs:
             echo "$response" \
               | jq -c ".data[] | select(.Company_slug != null and .Company_slug != \"\") | {
                   Account_Name,
+                  company_slug: .Company_slug,
                   logo_url: (\"https://cache.armbian.com/images/vendors/150/\(.Company_slug).png\"),
                   Website,
                   Description,


### PR DESCRIPTION
Add a **`company_slug`** field to each `partners.json` record.

`Company_slug` is already pulled from Zoho Bigin (it's in the fetch `fields=…,Company_slug,…` and used to build `logo_url`), but it wasn't emitted. This just surfaces it in the output object:

```jq
{
  Account_Name,
  company_slug: .Company_slug,     # <-- added
  logo_url: ("…/vendors/150/\(.Company_slug).png"),
  Website, Description, Partnership_Status
}
```

So consumers can use the slug directly — e.g. to match a partner to its vendor/board slug (`BOARD_VENDOR`) or other `cache.armbian.com` asset paths — instead of re-deriving it from the logo URL.

Additive field; the `select(.Company_slug != null and != "")` guard already ensures it's present. YAML + jq filter validated. Regenerated on the next `Data: Update partners and maintainers` run (daily cron / dispatch), which commits `data/partners.json`.