### PR TITLE
release-targets: recommend PocketBeagle 2 minimal image

### DIFF
--- a/release-targets/exposed.map.overrides.yaml
+++ b/release-targets/exposed.map.overrides.yaml
@@ -82,3 +82,9 @@ overrides:
     desktop:
       branch: edge
       suffix: gnome_desktop
+
+  - boards: [pocketbeagle2]
+    # PocketBeagle 2 is headless, so recommend the Ubuntu minimal image
+    # instead of the desktop image selected by its current inventory metadata.
+    desktop:
+      suffix: minimal


### PR DESCRIPTION
## What changed

- Override the PocketBeagle 2 recommended Ubuntu image suffix from `gnome_desktop` to `minimal`.

## Why

PocketBeagle 2 is a headless board, but the current inventory metadata reports video support and causes `exposed.map` to recommend a GNOME desktop image. The per-board override makes the published recommendation select the existing minimal image instead.

The board does however still have a GPU so to some users generating graphical images may be useful. 

## Validation

- Parsed `release-targets/exposed.map.overrides.yaml` with PyYAML.
- Ran `scripts/generate_targets.py` against the current upstream `data/image-info.json`.
- Confirmed the generated PocketBeagle 2 patterns select both Trixie minimal and Resolute minimal images.
- Ran `git diff --check`.
