### PR TITLE
Tune low-memory Beagle board release targets

### DIFF
--- a/release-targets/exposed.map.overrides.yaml
+++ b/release-targets/exposed.map.overrides.yaml
@@ -82,3 +82,9 @@ overrides:
     desktop:
       branch: edge
       suffix: gnome_desktop
+
+  - boards: [beaglebadge]
+    # BeagleBadge has only 256 MB RAM. Keep its display capability in the
+    # inventory, but recommend the Ubuntu minimal image instead of GNOME.
+    desktop:
+      suffix: minimal

--- a/release-targets/targets-extensions.map.blacklist
+++ b/release-targets/targets-extensions.map.blacklist
@@ -19,3 +19,4 @@
 radxa-e54c:::REMOVE_EXTENSIONS="v4l2loopback-dkms"
 khadas-vim1s:::REMOVE_EXTENSIONS="v4l2loopback-dkms"
 khadas-vim4:::REMOVE_EXTENSIONS="v4l2loopback-dkms"
+beaglebadge:::REMOVE_EXTENSIONS="v4l2loopback-dkms"

--- a/release-targets/targets-release-apps.blacklist
+++ b/release-targets/targets-release-apps.blacklist
@@ -2,3 +2,5 @@ uefi-loong64
 gateway-gz80x
 oneplus-kebab
 xiaomi-elish
+beaglebadge
+pocketbeagle2


### PR DESCRIPTION
## Summary

- exclude `beaglebadge` and `pocketbeagle2` from application image release targets
- recommend an Ubuntu minimal image instead of GNOME for BeagleBadge
- remove the automatically added `v4l2loopback-dkms` extension from BeagleBadge image targets

## Rationale

BeagleBadge has 256 MB RAM and PocketBeagle 2 has 512 MB RAM. That is below the published memory requirements for prominent application images in this release set: Home Assistant documents a 2 GB minimum, while OpenMediaVault documents a 1 GiB minimum.

BeagleBadge retains its display capability in the board inventory because it supports ePaper and DSI. However, a minimal image is a more appropriate recommendation for its memory constraints, and the generic video classification should not add `v4l2loopback-dkms` to its images.

## Impact

- future app release lists omit both low-memory boards
- BeagleBadge remains in standard and nightly release targets
- its exposed Debian and Ubuntu recommendations both select minimal images
- its standard and nightly targets no longer enable `v4l2loopback-dkms`

## Validation

- `git diff --check`
- ran `scripts/generate_targets.py` against the current upstream `image-info.json`
- confirmed BeagleBadge is absent from `targets-release-apps.yaml`
- confirmed BeagleBadge remains in standard and nightly targets without `v4l2loopback-dkms`
- confirmed both generated BeagleBadge entries in `exposed.map` end in `_minimal.img.xz`
