### PR TITLE
Refactor CDN redirector workflow (dedupe + fix status classification)

### DIFF
--- a/.github/workflows/infrastructure-update-redirector-config.yml
+++ b/.github/workflows/infrastructure-update-redirector-config.yml
@@ -1,9 +1,22 @@
 name: "Infrastructure: Update CDN redirector"
-# Trigger this workflow on a manual dispatch or a scheduled time
+
+# Regenerate the CDN redirector's per-variant YAML config from the mirror fleet:
+#   Check  -> permissions
+#   build  -> fetch the reference index for each platform from the source of truth
+#   index  -> ask NetBox which mirror servers back each redirector variant
+#   check  -> compare every mirror against the reference (in sync / not / timeout)
+#   redirector -> turn the results into a per-variant redirector YAML
+#   Close  -> commit the YAMLs to the data branch and refresh the directory listing
+#
+# The five variants (debs-beta, debs, images, archive, cache) used to be five
+# copy-pasted index jobs, five check jobs and five redirector blocks. They are
+# now data-driven: the variant table lives once in scripts/redirector/, and the
+# index/check/redirector jobs run as matrices over it.
+
 on:
   repository_dispatch:
     types: ["Infrastructure: Update redirector"]
-  workflow_dispatch:   # Manually triggered via GitHub Actions UI
+  workflow_dispatch:
 
 env:
   GEODB: "/scripts/redirect-config/GeoLite2-City.mmdb"
@@ -19,12 +32,10 @@ concurrency:
 jobs:
 
   Check:
-
     name: "Check permissions"
     runs-on: "ubuntu-24.04"
     if: ${{ github.repository_owner == 'Armbian' }}
     steps:
-
       - name: "Check permissions"
         uses: armbian/actions/team-check@main
         with:
@@ -33,54 +44,43 @@ jobs:
           TEAM: "Release manager"
 
   build:
-    name: "Source of truth"
+    name: "Reference index: ${{ matrix.platform }}"
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'Armbian' }}
     needs: Check
     strategy:
-      fail-fast: true
+      fail-fast: true   # a missing reference makes every mirror look out of sync
       matrix:
-        platform:
-          - beta
-          - apt
-          - dl
-          - archive
-          - cache
+        platform: [ beta, apt, dl, archive, cache ]
     steps:
-
       - name: "Install dependencies: lftp"
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: lftp
           version: 1.0
 
-      - name: "Download from  ${{ env.SOURCE_OF_TRUTH }}${{ matrix.platform }}"
+      - name: "Download ${{ matrix.platform }} from ${{ env.SOURCE_OF_TRUTH }}"
         run: |
-
           set -euo pipefail
-
           mkdir -p source destination
 
           platform="${{ matrix.platform }}"
           source_of_truth="${{ env.SOURCE_OF_TRUTH }}"
 
-          if [[ "$platform" =~ ^(dl|archive)$ ]]; then
-              # Mirror only *.torrent files from */archive/ into ./source
-              pushd source >/dev/null
-              lftp -e "mirror --include-glob=*/archive/*.torrent --parallel=64; quit" "${source_of_truth}/${platform}"
-              popd >/dev/null
+          # lftp mirror is the flaky step; retry a few times before giving up so a
+          # transient blip no longer needs a whole-run re-run.
+          retry() { local n=0; until "$@"; do n=$((n+1)); [[ $n -ge 3 ]] && return 1; sleep $((n*10)); done; }
 
-              # Move top-level archive subdirs from source to destination
+          if [[ "$platform" =~ ^(dl|archive)$ ]]; then
+              # Mirror only */archive/*.torrent into ./source, then lift the archive subdirs out.
+              ( cd source && retry lftp -e "mirror --include-glob=*/archive/*.torrent --parallel=64; quit" "${source_of_truth}/${platform}" )
               find source/*/archive/ -mindepth 1 -maxdepth 1 -exec mv -i -- "{}" destination/ \;
           elif [[ "$platform" == "cache" ]]; then
-              :
-              touch source/valid
-              touch destination/valid
+              # Cache isn't index-compared; ship a placeholder so the artifact exists.
+              touch source/valid destination/valid
           else
-              # Mirror dists directly into ./destination
-              pushd destination >/dev/null
-              lftp -e "mirror --parallel=64; quit" "${source_of_truth}/${platform}/dists"
-              popd >/dev/null
+              # APT: mirror the dists tree into ./destination.
+              ( cd destination && retry lftp -e "mirror --parallel=64; quit" "${source_of_truth}/${platform}/dists" )
           fi
 
       - name: "Upload ${{ matrix.platform }} index"
@@ -91,633 +91,189 @@ jobs:
           compression-level: 0
           retention-days: 2
 
-  Debs-beta-index:
-    name: "Compare beta deb mirrors"
-    needs: build
-    outputs:
-      matrix: ${{steps.json.outputs.JSON_CONTENT}}
+  index:
+    name: "Resolve mirror fleet from NetBox"
     runs-on: ubuntu-24.04
+    needs: Check
+    outputs:
+      matrix: ${{ steps.q.outputs.matrix }}
     steps:
-
-      - name: "Get beta packages mirrors from database"
-        id: json
+      - uses: actions/checkout@v7
+      - name: "Query NetBox"
+        id: q
+        env:
+          NETBOX_API: ${{ secrets.NETBOX_API }}
+          NETBOX_TOKEN: ${{ secrets.NETBOX_TOKEN }}
         run: |
+          set -euo pipefail
+          matrix="$(scripts/redirector/netbox-mirrors.sh)"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "Resolved $(jq 'length' <<<"${matrix}") mirror(s)." >> "$GITHUB_STEP_SUMMARY"
 
-          echo 'JSON_CONTENT<<EOF' >> $GITHUB_OUTPUT
-          curl -H "Authorization: Token ${{ secrets.NETBOX_TOKEN }}" -H "Accept: application/json; indent=4" \
-          "${{ secrets.NETBOX_API }}/virtualization/virtual-machines/?limit=500&name__empty=false&tag=debs-beta&status=active" \
-          | jq '.results[] | .name,.custom_fields["download_path_debs"],.id' | sed "s|null|beta|" | sed "s/\"//g" \
-          | xargs -n3 -d'\n' | sed -e 's/\s\+/\//' | sed "s/ /,/" | jq -cnR '[inputs | select(length>0)]' | jq >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-  Debs-stable-index:
-    name: "Compare stable deb mirrors"
-    needs: build
-    outputs:
-      matrix: ${{steps.json.outputs.JSON_CONTENT}}
+  check:
+    name: "Check ${{ matrix.node.server }}"
     runs-on: ubuntu-24.04
-    steps:
-
-      - name: "Get beta packages mirrors from database"
-        id: json
-        run: |
-
-          echo 'JSON_CONTENT<<EOF' >> $GITHUB_OUTPUT
-          curl -H "Authorization: Token ${{ secrets.NETBOX_TOKEN }}" -H "Accept: application/json; indent=4" \
-          "${{ secrets.NETBOX_API }}/virtualization/virtual-machines/?limit=500&name__empty=false&tag=debs&status=active" \
-          | jq '.results[] | .name,.custom_fields["download_path_debs"],.id' | sed "s|null|apt|" | sed "s/\"//g" \
-          | xargs -n3 -d'\n' | sed -e 's/\s\+/\//' | sed "s/ /,/" | jq -cnR '[inputs | select(length>0)]' | jq >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-  Images-stable-index:
-    name: "Compare stable images mirrors"
-    needs: build
-    outputs:
-      matrix: ${{steps.json.outputs.JSON_CONTENT}}
-    runs-on: ubuntu-24.04
-    steps:
-
-      - name: "Get stable images mirrors from database"
-        id: json
-        run: |
-
-          echo 'JSON_CONTENT<<EOF' >> $GITHUB_OUTPUT
-          curl -H "Authorization: Token ${{ secrets.NETBOX_TOKEN }}" -H "Accept: application/json; indent=4" \
-          "${{ secrets.NETBOX_API }}/virtualization/virtual-machines/?limit=500&name__empty=false&tag=images&status=active" \
-          | jq '.results[] | .name,.custom_fields["download_path_images"],.id' | sed "s|null|dl|" | sed "s/\"//g" \
-          | xargs -n3 -d'\n' | sed -e 's/\s\+/\//' | sed "s/ /,/" | jq -cnR '[inputs | select(length>0)]' | jq >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-  Images-archive-index:
-    name: "Compare archive images mirrors"
-    needs: build
-    outputs:
-      matrix: ${{steps.json.outputs.JSON_CONTENT}}
-    runs-on: ubuntu-24.04
-    steps:
-
-      - name: "Get archive images mirrors from database"
-        id: json
-        run: |
-
-          echo 'JSON_CONTENT<<EOF' >> $GITHUB_OUTPUT
-          curl -H "Authorization: Token ${{ secrets.NETBOX_TOKEN }}" -H "Accept: application/json; indent=4" \
-          "${{ secrets.NETBOX_API }}/virtualization/virtual-machines/?limit=500&name__empty=false&tag=archive&status=active" \
-          | jq '.results[] | .name,.custom_fields["download_path_images"],.id' | sed "s|null|archive|" | sed "s/\"//g" \
-          | xargs -n3 -d'\n' | sed -e 's/\s\+/\//' | sed "s/ /,/" | jq -cnR '[inputs | select(length>0)]' | jq >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-  Cache-index:
-    name: "Compare cache mirrors"
-    needs: build
-    outputs:
-      matrix: ${{steps.json.outputs.JSON_CONTENT}}
-    runs-on: ubuntu-24.04
-    steps:
-
-      - name: "Get cache mirrors from database"
-        id: json
-        run: |
-
-          echo 'JSON_CONTENT<<EOF' >> $GITHUB_OUTPUT
-          curl -H "Authorization: Token ${{ secrets.NETBOX_TOKEN }}" -H "Accept: application/json; indent=4" \
-          "${{ secrets.NETBOX_API }}/virtualization/virtual-machines/?limit=500&name__empty=false&tag=cache&status=active" \
-          | jq '.results[] | .name,.custom_fields["download_path_cache"],.id' | sed "s|null|cache|" | sed "s/\"//g" \
-          | xargs -n3 -d'\n' | sed -e 's/\s\+/\//' | sed "s/ /,/" | jq -cnR '[inputs | select(length>0)]' | jq >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-  Debs-beta:
-    name: "B"
-    runs-on: ubuntu-24.04
-    needs: [ Debs-beta-index ]
-    outputs:
-      matrix: ${{needs.Debs-beta-index.outputs.matrix}}
-    if: ${{ needs.Debs-beta-index.outputs.matrix != '[]' && needs.Debs-beta-index.outputs.matrix != '' }}
+    needs: [ build, index ]
+    if: ${{ needs.index.outputs.matrix != '' && needs.index.outputs.matrix != '[]' }}
     timeout-minutes: 7
     strategy:
       fail-fast: false
       matrix:
-        node: ${{fromJson(needs.Debs-beta-index.outputs.matrix)}}
-        
+        node: ${{ fromJson(needs.index.outputs.matrix) }}
     steps:
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v8
-        with:
-          name: beta
-          path: debs-beta
-
-      - name: "Install dependencies"
+      - name: "Install dependencies: lftp"
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: lftp
           version: 1.0
 
-      - name: "Check ${{ matrix.node }} "
+      - name: "Fetch reference index (${{ matrix.node.reference }})"
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.node.reference }}
+          path: reference
+
+      - name: "Compare mirror"
         run: |
+          scripts/redirector/check-mirror.sh \
+            "${{ matrix.node.server }}" \
+            "${{ matrix.node.check }}" \
+            reference \
+            "${{ matrix.node.id }}"
 
-          SERVER_URL=$(echo "${{ matrix.node }}" | cut -d"," -f1)
-          SERVER_ID=$(echo "${{ matrix.node }}" | cut -d"," -f2)
-          echo "SERVER_ID=${SERVER_ID}" >> $GITHUB_ENV
-          mkdir -p compare; cd compare
-          if curl --output /dev/null --silent --head --fail "https://${SERVER_URL}/dists/"; then
-              timeout 3m lftp -e "mirror --parallel=16; exit" https://${SERVER_URL}/dists/ || true
-          fi
-          cd ..
-          OUT=$(diff -rq compare debs || true)
-          mkdir -p status
-          if [[ -z "${OUT}" ]]; then
-              echo "true" >> status/${SERVER_ID}
-              echo "STATUS=true" >> $GITHUB_ENV
-          elif [[ "${exit_status}" -eq 0 ]]; then
-              echo "not_in_sync" >> status/${SERVER_ID}
-              echo "${SERVER_URL}" >> status/${SERVER_ID}
-              echo "STATUS=not_in_sync" >> $GITHUB_ENV
-          elif [[ "${exit_status}" -eq 124 ]]; then
-              echo "timeout" >> status/${SERVER_ID}
-              echo "${SERVER_URL}" >> status/${SERVER_ID}
-              echo "STATUS=not_in_sync" >> $GITHUB_ENV
-          fi
-
-      - name: Upload ${{ env.STATUS }} for ${{ matrix.node }}
+      - name: "Upload status"
         uses: actions/upload-artifact@v7
         with:
-          name: debs-beta-${{ env.SERVER_ID }}
+          name: mirror-status-${{ matrix.node.key }}-${{ matrix.node.id }}
           path: status
           if-no-files-found: ignore
 
-  Debs-stable:
-    name: "S"
+  redirector:
+    name: "Redirector config: ${{ matrix.variant }}"
     runs-on: ubuntu-24.04
-    needs: [ Debs-stable-index ]
-    outputs:
-      matrix: ${{needs.Debs-stable-index.outputs.matrix}}
-    if: ${{ needs.Debs-stable-index.outputs.matrix != '[]' && needs.Debs-stable-index.outputs.matrix != '' }}
-    timeout-minutes: 7
+    needs: check
     strategy:
       fail-fast: false
       matrix:
-        node: ${{fromJson(needs.Debs-stable-index.outputs.matrix)}}
-        
+        include:
+          - { key: debsbeta, variant: debs-beta, port: "8083" }
+          - { key: debs,     variant: debs,      port: "" }
+          - { key: images,   variant: images,    port: "8081" }
+          - { key: archive,  variant: archive,   port: "8082" }
+          - { key: cache,    variant: cache,     port: "8084" }
     steps:
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v8
+      - name: "Collect ${{ matrix.variant }} statuses"
+        uses: actions/download-artifact@v8
         with:
-          name: apt
-          path: debs
-
-      - name: "Install dependencies"
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: lftp
-          version: 1.0
-
-      - name: "Check ${{ matrix.node }} "
-        run: |
-
-          SERVER_URL=$(echo "${{ matrix.node }}" | cut -d"," -f1)
-          SERVER_ID=$(echo "${{ matrix.node }}" | cut -d"," -f2)
-          echo "SERVER_ID=${SERVER_ID}" >> $GITHUB_ENV
-          mkdir -p compare; cd compare
-          if curl --output /dev/null --silent --head --fail "https://${SERVER_URL}/dists/"; then
-              timeout 3m lftp -e "mirror --parallel=16; exit" https://${SERVER_URL}/dists/ || exit_status=$?
-          fi
-          cd ..
-          OUT=$(diff -rq compare debs || true)
-          mkdir -p status
-          if [[ -z "${OUT}" ]]; then
-              echo "true" >> status/${SERVER_ID}
-              echo "STATUS=true" >> $GITHUB_ENV
-          elif [[ "${exit_status}" -eq 0 ]]; then
-              echo "not_in_sync" >> status/${SERVER_ID}
-              echo "${SERVER_URL}" >> status/${SERVER_ID}
-              echo "STATUS=not_in_sync" >> $GITHUB_ENV
-          elif [[ "${exit_status}" -eq 124 ]]; then
-              echo "timeout" >> status/${SERVER_ID}
-              echo "${SERVER_URL}" >> status/${SERVER_ID}
-              echo "STATUS=not_in_sync" >> $GITHUB_ENV
-          fi
-
-      - name: Upload ${{ env.STATUS }} for ${{ matrix.node }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: debs-${{ env.SERVER_ID }}
           path: status
-          if-no-files-found: ignore
+          pattern: mirror-status-${{ matrix.key }}-*
+          merge-multiple: true
 
-  Images-stable:
-    name: "I"
-    runs-on: ubuntu-24.04
-    needs: [ Images-stable-index ]
-    outputs:
-      matrix: ${{needs.Images-stable-index.outputs.matrix}}
-    if: ${{ needs.Images-stable-index.outputs.matrix != '[]' && needs.Images-stable-index.outputs.matrix != '' }}
-    timeout-minutes: 7
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ${{fromJson(needs.Images-stable-index.outputs.matrix)}}
+      - name: "Summarize"
+        run: scripts/redirector/summarize.sh status
 
-    steps:
-
-      - uses: actions/download-artifact@v8
+      - name: "Generate ${{ matrix.variant }} redirector YAML"
+        if: ${{ matrix.port != '' }}
+        uses: armbian/actions/make-yaml-redirector@main
         with:
-          name: dl
-          path: dl
+          variant: ${{ matrix.variant }}
+          failoverserver: "${{ env.failoverserver }}"
+          port: ${{ matrix.port }}
+          geodb: "${{ env.GEODB }}"
+          asndb: "${{ env.ASNDB }}"
+          dl_map: "${{ env.DL_MAP }}"
+          certDataPath: "${{ env.CERTPATH }}"
+          reloadKey: ${{ env.reloadKey }}
+          netbox: ${{ secrets.NETBOX_TOKEN }}
+          netboxapi: ${{ secrets.NETBOX_API }}
 
-      - name: "Install dependencies"
-        uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: "Generate ${{ matrix.variant }} redirector YAML (default port)"
+        if: ${{ matrix.port == '' }}
+        uses: armbian/actions/make-yaml-redirector@main
         with:
-          packages: lftp
-          version: 1.0
-
-      - name: "Check ${{ matrix.node }} "
-        run: |
-
-          SERVER_URL=$(echo "${{ matrix.node }}" | cut -d"," -f1)
-          SERVER_ID=$(echo "${{ matrix.node }}" | cut -d"," -f2)
-          echo "SERVER_ID=${SERVER_ID}" >> $GITHUB_ENV
-          mkdir -p compare source; cd source
-          if curl --output /dev/null --silent --head --fail "https://${SERVER_URL}"; then
-              timeout 3m lftp -e "mirror --include-glob=*/archive/*.torrent --parallel=64; exit" https://${SERVER_URL} || exit_status=$?
-              cd ..              
-              find source/*/archive/ -mindepth 1 -maxdepth 1 -exec mv -i -- {} compare/ \; || true
-          fi
-          OUT=$(diff -rq compare dl || true)
-          mkdir -p status
-          if [[ -z "${OUT}" ]]; then
-              echo "true" >> status/${SERVER_ID}
-              echo "STATUS=true" >> $GITHUB_ENV
-          elif [[ "${exit_status}" -eq 0 ]]; then
-              echo "not_in_sync" >> status/${SERVER_ID}
-              echo "${SERVER_URL}" >> status/${SERVER_ID}
-              echo "STATUS=not_in_sync" >> $GITHUB_ENV
-          elif [[ "${exit_status}" -eq 124 ]]; then
-              echo "timeout" >> status/${SERVER_ID}
-              echo "${SERVER_URL}" >> status/${SERVER_ID}
-              echo "STATUS=not_in_sync" >> $GITHUB_ENV
-          fi
-
-      - name: Upload ${{ env.STATUS }} for ${{ matrix.node }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: dl-${{ env.SERVER_ID }}
-          path: status
-          if-no-files-found: ignore
-
-  Images-archive:
-    name: "A"
-    runs-on: ubuntu-24.04
-    needs: [ Images-archive-index ]
-    outputs:
-      matrix: ${{needs.Images-archive-index.outputs.matrix}}
-    if: ${{ needs.Images-archive-index.outputs.matrix != '[]' && needs.Images-archive-index.outputs.matrix != '' }}
-    timeout-minutes: 7
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ${{fromJson(needs.Images-archive-index.outputs.matrix)}}
-
-    steps:
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: archive
-          path: archive
-
-      - name: "Install dependencies"
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: lftp
-          version: 1.0
-
-      - name: "Check ${{ matrix.node }} "
-        run: |
-
-          SERVER_URL=$(echo "${{ matrix.node }}" | cut -d"," -f1)
-          SERVER_ID=$(echo "${{ matrix.node }}" | cut -d"," -f2)
-          echo "SERVER_ID=${SERVER_ID}" >> $GITHUB_ENV
-          mkdir -p compare source; cd source
-          if curl --output /dev/null --silent --head --fail "https://${SERVER_URL}"; then
-              timeout 3m lftp -e "mirror --include-glob=*/archive/*.torrent --parallel=64; exit" https://${SERVER_URL} || exit_status=$?
-              cd ..              
-              find source/*/archive/ -mindepth 1 -maxdepth 1 -exec mv -i -- {} compare/ \; || true
-          fi
-          OUT=$(diff -rq compare archive || true)
-          mkdir -p status
-          if [[ -z "${OUT}" ]]; then
-              echo "true" >> status/${SERVER_ID}
-              echo "STATUS=true" >> $GITHUB_ENV
-          elif [[ "${exit_status}" -eq 0 ]]; then
-              echo "not_in_sync" >> status/${SERVER_ID}
-              echo "${SERVER_URL}" >> status/${SERVER_ID}
-              echo "STATUS=not_in_sync" >> $GITHUB_ENV
-          elif [[ "${exit_status}" -eq 124 ]]; then
-              echo "timeout" >> status/${SERVER_ID}
-              echo "${SERVER_URL}" >> status/${SERVER_ID}
-              echo "STATUS=not_in_sync" >> $GITHUB_ENV
-          fi
-
-      - name: Upload ${{ env.STATUS }} for ${{ matrix.node }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: archive-${{ env.SERVER_ID }}
-          path: status
-          if-no-files-found: ignore
-
-  Cache:
-    name: "C"
-    runs-on: ubuntu-24.04
-    needs: [ Cache-index ]
-    outputs:
-      matrix: ${{needs.Cache-index.outputs.matrix}}
-    if: ${{ needs.Cache-index.outputs.matrix != '[]' && needs.Cache-index.outputs.matrix != '' }}
-    timeout-minutes: 7
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ${{fromJson(needs.Cache-index.outputs.matrix)}}
-
-    steps:
-
-      - name: "Check ${{ matrix.node }} "
-        run: |
-
-          SERVER_ID=$(echo "${{ matrix.node }}" | cut -d"," -f2)
-          echo "SERVER_ID=${SERVER_ID}" >> $GITHUB_ENV
-          mkdir -p status
-          echo "true" >> status/${SERVER_ID}
-          echo "STATUS=true" >> $GITHUB_ENV
-
-      - name: Upload ${{ env.STATUS }} for ${{ matrix.node }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: cache-${{ env.SERVER_ID }}
-          path: status
-          if-no-files-found: ignore
-
-  download:
-    needs: [ Debs-beta,Debs-stable,Images-stable,Images-archive,Cache ]
-    runs-on: ubuntu-24.04
-    steps:
-
-    - name: Download All Artifacts
-      uses: actions/download-artifact@v8
-      with:
-        path: status
-        pattern: debs-beta-*
-        merge-multiple: true
-
-    - name: "Start log"
-      run: |
-
-        echo "# Test summary" >> $GITHUB_STEP_SUMMARY
-
-
-    - name: "Grep only those that are in sync"
-      run: |
-        echo "# Not in sync" >> $GITHUB_STEP_SUMMARY
-        #echo "$(grep not_in_sync status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_STEP_SUMMARY
-        grep not_in_sync status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        echo "# Timeouts" >> $GITHUB_STEP_SUMMARY
-        grep timeout status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        #echo "$(grep timeout status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_STEP_SUMMARY
-
-        echo "failoverserver=$(grep true status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_ENV
-        echo "reloadKey=$(openssl rand -hex 16)" >> $GITHUB_ENV
-        rm -rf status
-
-    - name: Test debs
-      uses: armbian/actions/make-yaml-redirector@main
-      with:
-        variant: debs-beta
-        failoverserver: "${{ env.failoverserver }}"
-        port: 8083
-        geodb: "${{ env.GEODB }}"
-        asndb: "${{ env.ASNDB }}"        
-        dl_map: "${{ env.DL_MAP }}"
-        certDataPath: "${{ env.CERTPATH }}"
-        reloadKey: ${{ env.reloadKey }}
-        netbox: ${{ secrets.NETBOX_TOKEN }}
-        netboxapi: ${{ secrets.NETBOX_API }}
-
-    - name: Download All Artifacts
-      uses: actions/download-artifact@v8
-      with:
-        path: status
-        pattern: debs*
-        merge-multiple: true
-
-    - name: "Grep only those that are in sync"
-      run: |
-        echo "# Not in sync" >> $GITHUB_STEP_SUMMARY
-        #echo "$(grep not_in_sync status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_STEP_SUMMARY
-        grep not_in_sync status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        echo "# Timeouts" >> $GITHUB_STEP_SUMMARY
-        grep timeout status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        #echo "$(grep timeout status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_STEP_SUMMARY
-        echo "failoverserver=$(grep true status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_ENV
-        echo "reloadKey=$(openssl rand -hex 16)" >> $GITHUB_ENV
-        rm -rf status
-
-    - name: Stable debs
-      uses: armbian/actions/make-yaml-redirector@main
-      with:
-        variant: debs
-        failoverserver: "${{ env.failoverserver }}"
-        geodb: "${{ env.GEODB }}"
-        asndb: "${{ env.ASNDB }}"
-        dl_map: "${{ env.DL_MAP }}"
-        certDataPath: "${{ env.CERTPATH }}"
-        reloadKey: ${{ env.reloadKey }}
-        netbox: ${{ secrets.NETBOX_TOKEN }}
-        netboxapi: ${{ secrets.NETBOX_API }}
-
-    - name: Download All Artifacts
-      uses: actions/download-artifact@v8
-      with:
-        path: status
-        pattern: dl*
-        merge-multiple: true
-
-    - name: "Grep only those that are in sync"
-      run: |
-        echo "# Not in sync" >> $GITHUB_STEP_SUMMARY
-        #echo "$(grep not_in_sync status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_STEP_SUMMARY
-        grep not_in_sync status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        echo "# Timeouts" >> $GITHUB_STEP_SUMMARY
-        grep timeout status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        #echo "$(grep timeout status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_STEP_SUMMARY
-
-        echo "failoverserver=$(grep true status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_ENV
-        echo "reloadKey=$(openssl rand -hex 16)" >> $GITHUB_ENV
-        rm -rf status
-
-    - name: Images
-      uses: armbian/actions/make-yaml-redirector@main
-      with:
-        variant: images
-        failoverserver: "${{ env.failoverserver }}"
-        port: 8081
-        geodb: "${{ env.GEODB }}"
-        asndb: "${{ env.ASNDB }}"
-        dl_map: "${{ env.DL_MAP }}"
-        certDataPath: "${{ env.CERTPATH }}"
-        reloadKey: ${{ env.reloadKey }}
-        netbox: ${{ secrets.NETBOX_TOKEN }}
-        netboxapi: ${{ secrets.NETBOX_API }}
-
-    - name: Download All Artifacts
-      uses: actions/download-artifact@v8
-      with:
-        path: status
-        pattern: archive*
-        merge-multiple: true
-
-    - name: "Grep only those that are in sync"
-      run: |
-        echo "# Not in sync" >> $GITHUB_STEP_SUMMARY
-        #echo "$(grep not_in_sync status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_STEP_SUMMARY
-        grep not_in_sync status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        echo "# Timeouts" >> $GITHUB_STEP_SUMMARY
-        grep timeout status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        #echo "$(grep timeout status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_STEP_SUMMARY
-
-        echo "failoverserver=$(grep true status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_ENV
-        echo "reloadKey=$(openssl rand -hex 16)" >> $GITHUB_ENV
-        rm -rf status
-
-    - name: Archive
-      uses: armbian/actions/make-yaml-redirector@main
-      with:
-        variant: archive
-        failoverserver: "${{ env.failoverserver }}"
-        port: 8082
-        geodb: "${{ env.GEODB }}"
-        asndb: "${{ env.ASNDB }}"
-        dl_map: "${{ env.DL_MAP }}"
-        certDataPath: "${{ env.CERTPATH }}"
-        reloadKey: ${{ env.reloadKey }}
-        netbox: ${{ secrets.NETBOX_TOKEN }}
-        netboxapi: ${{ secrets.NETBOX_API }}
-
-    - name: Download All Artifacts
-      uses: actions/download-artifact@v8
-      with:
-        path: status
-        pattern: cache*
-        merge-multiple: true
-
-    - name: "Grep only those that are in sync"
-      run: |
-        echo "# Not in sync" >> $GITHUB_STEP_SUMMARY
-        grep not_in_sync status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-        echo "# Timeouts" >> $GITHUB_STEP_SUMMARY
-        grep timeout status/* | cut -d":" -f1 | xargs awk 'FNR==2{print}' >> $GITHUB_STEP_SUMMARY
-
-        echo "failoverserver=$(grep true status/* | cut -d":" -f1 | cut -d"/" -f2 | sed ':a; N; s/\n/ /; ta') " >> $GITHUB_ENV
-        echo "reloadKey=$(openssl rand -hex 16)" >> $GITHUB_ENV
-        rm -rf status
-
-    - name: Cache
-      uses: armbian/actions/make-yaml-redirector@main
-      with:
-        variant: cache
-        failoverserver: "${{ env.failoverserver }}"
-        port: 8084
-        geodb: "${{ env.GEODB }}"
-        asndb: "${{ env.ASNDB }}"
-        dl_map: "${{ env.DL_MAP }}"
-        certDataPath: "${{ env.CERTPATH }}"
-        reloadKey: ${{ env.reloadKey }}
-        netbox: ${{ secrets.NETBOX_TOKEN }}
-        netboxapi: ${{ secrets.NETBOX_API }}
+          variant: ${{ matrix.variant }}
+          failoverserver: "${{ env.failoverserver }}"
+          geodb: "${{ env.GEODB }}"
+          asndb: "${{ env.ASNDB }}"
+          dl_map: "${{ env.DL_MAP }}"
+          certDataPath: "${{ env.CERTPATH }}"
+          reloadKey: ${{ env.reloadKey }}
+          netbox: ${{ secrets.NETBOX_TOKEN }}
+          netboxapi: ${{ secrets.NETBOX_API }}
 
   Close:
-    needs: [ download ]
+    needs: redirector
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          path: armbian.github.io
 
-    - name: Checkout repository
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
-        path: armbian.github.io
+      - uses: robinraju/release-downloader@v1.13
+        with:
+          repository: "P3TERX/GeoLite.mmdb"
+          fileName: "*.mmdb"
+          latest: true
 
-    - uses: robinraju/release-downloader@v1.13
-      with:
-        repository: "P3TERX/GeoLite.mmdb"
-        fileName: "*.mmdb"
-        latest: true
-        
-    - name: Download All Artifacts
-      uses: actions/download-artifact@v8
-      with:
-        path: status
-        pattern: config-*
-        merge-multiple: true
+      - name: Download redirector configs
+        uses: actions/download-artifact@v8
+        with:
+          path: status
+          pattern: config-*
+          merge-multiple: true
 
-    - name: "Check"
-      run: |
+      - name: "Commit changes if any"
+        run: |
+          set -euo pipefail
+          cd armbian.github.io
 
-        ls -l status
-        echo "-"
-        ls -l ${{ github.workspace }}/
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
 
-    - name: Commit changes if any
-      run: |
-        set -euo pipefail
-        cd armbian.github.io
+          git fetch origin data
+          git checkout data
 
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
+          mkdir -p data
+          cp "${{ github.workspace }}"/status/*.yaml data/
+          cp "${{ github.workspace }}"/*.mmdb data/
 
-        git fetch origin data
-        git checkout data
+          git add data/
+          if ! git diff --cached --quiet; then
+            git commit -m "Update Redirector YAML configuration"
+            # Push with retry logic
+            max_attempts=3
+            attempt=1
+            while [ $attempt -le $max_attempts ]; do
+              if git push origin data; then
+                echo "Successfully pushed to data branch"
+                exit 0
+              fi
+              echo "Push failed, attempting to pull and rebase..." >&2
+              git pull --rebase origin data || echo "Pull/rebase failed, will retry push..." >&2
+              attempt=$((attempt + 1))
+            done
+            echo "Failed to push after $max_attempts attempts" >&2
+            exit 1
+          fi
 
-        mkdir -p data
-        cp ${{ github.workspace }}/status/*.yaml data/
-        cp ${{ github.workspace }}/*.mmdb data/
-
-        git add data/
-        if ! git diff --cached --quiet; then
-          git commit -m "Update Redirector YAML configuration"
-          # Push with retry logic
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            if git push origin data; then
-              echo "Successfully pushed to data branch"
-              exit 0
-            fi
-
-            # Pull with rebase to resolve conflicts
-            echo "Push failed, attempting to pull and rebase..." >&2
-            if ! git pull --rebase origin data; then
-              echo "Pull/rebase failed, will retry push..." >&2
-            fi
-
-            attempt=$((attempt + 1))
-          done
-
-          echo "Failed to push after $max_attempts attempts" >&2
-          exit 1
-        fi
-
-    - uses: geekyeggo/delete-artifact@v6
-      with:
-        name: |
-            debs-*
-            dl-*
-            archive-*
-            cache-*
+      - uses: geekyeggo/delete-artifact@v6
+        with:
+          name: |
+            mirror-status-*
             apt
             beta
             dl
             archive
             cache
 
-    - name: "Generate directory"
-      uses: peter-evans/repository-dispatch@v4
-      with:
-        token: ${{ secrets.DISPATCH }}
-        event-type: "Web: Directory listing"
+      - name: "Generate directory"
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.DISPATCH }}
+          event-type: "Web: Directory listing"

--- a/.github/workflows/infrastructure-update-redirector-config.yml
+++ b/.github/workflows/infrastructure-update-redirector-config.yml
@@ -78,7 +78,8 @@ jobs:
           if [[ "$platform" =~ ^(dl|archive)$ ]]; then
               # Mirror only */archive/*.torrent into ./source, then lift the archive subdirs out.
               ( cd source && retry lftp -e "mirror --include-glob=*/archive/*.torrent --parallel=64; quit" "${source_of_truth}/${platform}" )
-              find source/*/archive/ -mindepth 1 -maxdepth 1 -exec mv -i -- "{}" destination/ \;
+              # -f, not -i: with no tty the prompt reads EOF and declines the move.
+          find source/*/archive/ -mindepth 1 -maxdepth 1 -exec mv -f -- "{}" destination/ \;
           elif [[ "$platform" == "cache" ]]; then
               # Cache isn't index-compared; ship a placeholder so the artifact exists.
               touch source/valid destination/valid
@@ -103,6 +104,8 @@ jobs:
       matrix: ${{ steps.q.outputs.matrix }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: "Query NetBox"
         id: q
         env:
@@ -111,8 +114,15 @@ jobs:
         run: |
           set -euo pipefail
           matrix="$(scripts/redirector/netbox-mirrors.sh)"
+          count="$(jq 'length' <<<"${matrix}")"
+          # A matrix over 256 entries is rejected by Actions at dispatch time,
+          # which reads as a workflow-syntax error rather than "fleet too big".
+          if [[ "${count}" -gt 256 ]]; then
+            echo "index: ${count} mirror/variant pairs exceeds the 256-job matrix limit; the check job needs chunking" >&2
+            exit 1
+          fi
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
-          echo "Resolved $(jq 'length' <<<"${matrix}") mirror(s)." >> "$GITHUB_STEP_SUMMARY"
+          echo "Resolved ${count} mirror(s)." >> "$GITHUB_STEP_SUMMARY"
 
   mirrors:
     name: "Check ${{ matrix.node.server }}"
@@ -126,6 +136,8 @@ jobs:
         node: ${{ fromJson(needs.index.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: "Install dependencies: lftp"
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -140,12 +152,19 @@ jobs:
           path: reference
 
       - name: "Compare mirror"
+        env:
+          # Via env, never inline in `run`: these come from NetBox, and a crafted
+          # VM name would otherwise be interpolated straight into the shell.
+          NODE_SERVER: ${{ matrix.node.server }}
+          NODE_CHECK: ${{ matrix.node.check }}
+          NODE_ID: ${{ matrix.node.id }}
         run: |
+          set -euo pipefail
           scripts/redirector/check-mirror.sh \
-            "${{ matrix.node.server }}" \
-            "${{ matrix.node.check }}" \
+            "${NODE_SERVER}" \
+            "${NODE_CHECK}" \
             reference \
-            "${{ matrix.node.id }}"
+            "${NODE_ID}"
 
       - name: "Upload status"
         uses: actions/upload-artifact@v7
@@ -169,6 +188,8 @@ jobs:
           - { key: cache,    variant: cache,     port: "8084" }
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: "Collect ${{ matrix.variant }} statuses"
         uses: actions/download-artifact@v8
@@ -180,27 +201,14 @@ jobs:
       - name: "Summarize"
         run: scripts/redirector/summarize.sh status
 
+      # One invocation for every variant: the action emits `bind:` only when port
+      # is non-empty, so debs (no explicit port) keeps the default as before.
       - name: "Generate ${{ matrix.variant }} redirector YAML"
-        if: ${{ matrix.port != '' }}
         uses: armbian/actions/make-yaml-redirector@main
         with:
           variant: ${{ matrix.variant }}
           failoverserver: "${{ env.failoverserver }}"
-          port: ${{ matrix.port }}
-          geodb: "${{ env.GEODB }}"
-          asndb: "${{ env.ASNDB }}"
-          dl_map: "${{ env.DL_MAP }}"
-          certDataPath: "${{ env.CERTPATH }}"
-          reloadKey: ${{ env.reloadKey }}
-          netbox: ${{ secrets.NETBOX_TOKEN }}
-          netboxapi: ${{ secrets.NETBOX_API }}
-
-      - name: "Generate ${{ matrix.variant }} redirector YAML (default port)"
-        if: ${{ matrix.port == '' }}
-        uses: armbian/actions/make-yaml-redirector@main
-        with:
-          variant: ${{ matrix.variant }}
-          failoverserver: "${{ env.failoverserver }}"
+          port: "${{ matrix.port }}"
           geodb: "${{ env.GEODB }}"
           asndb: "${{ env.ASNDB }}"
           dl_map: "${{ env.DL_MAP }}"
@@ -273,6 +281,7 @@ jobs:
         with:
           name: |
             mirror-status-*
+            config-*
             apt
             beta
             dl

--- a/.github/workflows/infrastructure-update-redirector-config.yml
+++ b/.github/workflows/infrastructure-update-redirector-config.yml
@@ -29,6 +29,10 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+# Least-privilege default for GITHUB_TOKEN; jobs that need more opt in below.
+permissions:
+  contents: read
+
 jobs:
 
   Check:
@@ -208,6 +212,9 @@ jobs:
   Close:
     needs: redirector
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # push the regenerated YAMLs to the data branch
+      actions: write    # delete the intermediate index/status artifacts
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/infrastructure-update-redirector-config.yml
+++ b/.github/workflows/infrastructure-update-redirector-config.yml
@@ -110,7 +110,7 @@ jobs:
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
           echo "Resolved $(jq 'length' <<<"${matrix}") mirror(s)." >> "$GITHUB_STEP_SUMMARY"
 
-  check:
+  mirrors:
     name: "Check ${{ matrix.node.server }}"
     runs-on: ubuntu-24.04
     needs: [ build, index ]
@@ -153,7 +153,7 @@ jobs:
   redirector:
     name: "Redirector config: ${{ matrix.variant }}"
     runs-on: ubuntu-24.04
-    needs: check
+    needs: mirrors
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/redirector/check-mirror.sh
+++ b/scripts/redirector/check-mirror.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Compare one mirror server against the reference index and classify it.
+# Writes a single status file  status/<id>  whose first line is one of:
+#
+#   true          - in sync with the reference
+#   not_in_sync   - reachable but differs (or unreachable / no index)
+#   timeout       - the mirror pull hit the 3-minute cap
+#
+# For not_in_sync / timeout a second line carries the server, so the summary
+# step can list it.
+#
+# Usage: check-mirror.sh <server> <check-type> <reference-dir> <id>
+#   check-type: dists | torrents | noop
+#
+# This replaces five copy-pasted inline blocks and fixes their shared bug:
+# `exit_status` was used uninitialised and only some variants set it (debs-beta
+# used `|| true`), so out-of-sync / timeout servers were silently dropped.
+set -uo pipefail
+
+server="${1:?server (host/path) required}"
+check="${2:?check type required}"
+reference_dir="${3:?reference dir required}"
+id="${4:?server id required}"
+
+mkdir -p status compare
+
+# 0 = pull ok, 124 = timeout, anything else = pull error. Initialised so the
+# classification is well-defined even when the mirror is unreachable.
+exit_status=0
+
+case "${check}" in
+	noop)
+		# Cache mirrors aren't index-compared; they're always considered in sync.
+		echo "true" > "status/${id}"
+		exit 0
+		;;
+
+	dists)
+		# APT repositories: mirror the dists/ tree and diff it.
+		if curl -o /dev/null -sfI "https://${server}/dists/"; then
+			( cd compare && timeout 3m lftp -e "mirror --parallel=16; exit" "https://${server}/dists/" ) \
+				|| exit_status=$?
+		fi
+		;;
+
+	torrents)
+		# Image repositories: mirror only the archive/*.torrent files.
+		mkdir -p source
+		if curl -o /dev/null -sfI "https://${server}"; then
+			( cd source && timeout 3m lftp -e "mirror --include-glob=*/archive/*.torrent --parallel=64; exit" "https://${server}" ) \
+				|| exit_status=$?
+			find source/*/archive/ -mindepth 1 -maxdepth 1 -exec mv -i -- {} compare/ \; 2>/dev/null || true
+		fi
+		;;
+
+	*)
+		echo "check-mirror: unknown check type '${check}'" >&2
+		exit 2
+		;;
+esac
+
+# Empty diff => identical to the reference.
+if [[ -z "$(diff -rq compare "${reference_dir}" 2>/dev/null || true)" ]]; then
+	echo "true" > "status/${id}"
+elif [[ "${exit_status}" -eq 124 ]]; then
+	printf '%s\n%s\n' "timeout" "${server}" > "status/${id}"
+else
+	printf '%s\n%s\n' "not_in_sync" "${server}" > "status/${id}"
+fi

--- a/scripts/redirector/check-mirror.sh
+++ b/scripts/redirector/check-mirror.sh
@@ -3,8 +3,8 @@
 # Compare one mirror server against the reference index and classify it.
 # Writes a single status file  status/<id>  whose first line is one of:
 #
-#   true          - in sync with the reference
-#   not_in_sync   - reachable but differs (or unreachable / no index)
+#   true          - reachable AND identical to the reference
+#   not_in_sync   - reachable but differs, or unreachable / no index
 #   timeout       - the mirror pull hit the 3-minute cap
 #
 # For not_in_sync / timeout a second line carries the server, so the summary
@@ -28,6 +28,10 @@ mkdir -p status compare
 # 0 = pull ok, 124 = timeout, anything else = pull error. Initialised so the
 # classification is well-defined even when the mirror is unreachable.
 exit_status=0
+# Whether the mirror answered at all. An unreachable mirror leaves compare/
+# empty, which would diff clean against an empty reference and be published as
+# healthy - so reachability is tracked explicitly rather than inferred.
+reached=0
 
 case "${check}" in
 	noop)
@@ -39,6 +43,7 @@ case "${check}" in
 	dists)
 		# APT repositories: mirror the dists/ tree and diff it.
 		if curl -o /dev/null -sfI "https://${server}/dists/"; then
+			reached=1
 			( cd compare && timeout 3m lftp -e "mirror --parallel=16; exit" "https://${server}/dists/" ) \
 				|| exit_status=$?
 		fi
@@ -48,9 +53,12 @@ case "${check}" in
 		# Image repositories: mirror only the archive/*.torrent files.
 		mkdir -p source
 		if curl -o /dev/null -sfI "https://${server}"; then
+			reached=1
 			( cd source && timeout 3m lftp -e "mirror --include-glob=*/archive/*.torrent --parallel=64; exit" "https://${server}" ) \
 				|| exit_status=$?
-			find source/*/archive/ -mindepth 1 -maxdepth 1 -exec mv -i -- {} compare/ \; 2>/dev/null || true
+			# -f, not -i: with no tty an interactive prompt reads EOF and silently
+			# declines the move. Errors stay on stderr so a real failure is visible.
+			find source/*/archive/ -mindepth 1 -maxdepth 1 -exec mv -f -- {} compare/ \; || true
 		fi
 		;;
 
@@ -60,8 +68,16 @@ case "${check}" in
 		;;
 esac
 
-# Empty diff => identical to the reference.
-if [[ -z "$(diff -rq compare "${reference_dir}" 2>/dev/null || true)" ]]; then
+# An empty reference means the index job produced nothing: every mirror would
+# then diff clean and the whole fleet would be published as in sync. Refuse.
+if [[ -z "$(find "${reference_dir}" -mindepth 1 -print -quit 2>/dev/null)" ]]; then
+	echo "check-mirror: reference dir '${reference_dir}' is empty - refusing to classify ${server}" >&2
+	printf '%s\n%s\n' "not_in_sync" "${server}" > "status/${id}"
+	exit 0
+fi
+
+# In sync only when the mirror answered AND its content matches the reference.
+if [[ "${reached}" -eq 1 && -z "$(diff -rq compare "${reference_dir}" 2>/dev/null || true)" ]]; then
 	echo "true" > "status/${id}"
 elif [[ "${exit_status}" -eq 124 ]]; then
 	printf '%s\n%s\n' "timeout" "${server}" > "status/${id}"

--- a/scripts/redirector/netbox-mirrors.sh
+++ b/scripts/redirector/netbox-mirrors.sh
@@ -41,6 +41,14 @@ while IFS=$'\t' read -r key tag field fallback reference check; do
 		-H "Accept: application/json" \
 		"${NETBOX_API}/virtualization/virtual-machines/?limit=500&name__empty=false&status=active&tag=${tag}")
 
+	# limit=500 is a cap, not a promise. If NetBox ever pages the response the
+	# tail would vanish from the matrix silently and those mirrors would drop
+	# out of the failover pool - so fail loudly instead.
+	if [[ "$(jq -r '.next // "null"' <<<"${resp}")" != "null" ]]; then
+		echo "netbox-mirrors: paginated response for tag '${tag}' ($(jq -r '.count' <<<"${resp}") results); raise the limit or follow .next" >&2
+		exit 1
+	fi
+
 	# One clean jq pass per variant: server = name + "/" + download path (the
 	# custom field, or the fallback when it's null/absent).
 	part=$(jq -c \

--- a/scripts/redirector/netbox-mirrors.sh
+++ b/scripts/redirector/netbox-mirrors.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Query NetBox for the active mirror servers behind each redirector variant and
+# emit a single GitHub Actions matrix: a JSON array of node objects, one per
+# mirror server, each carrying everything the check job needs.
+#
+#   { "key": "images", "reference": "dl", "check": "torrents",
+#     "server": "mirror.example.com/dl", "id": "123" }
+#
+# "key"       - short, collision-free artifact prefix for this variant
+# "reference" - which build-job reference artifact to diff against
+# "check"     - how the mirror is compared (dists | torrents | noop)
+# "server"    - host + download path; the check hits https://<server>/...
+# "id"        - NetBox VM id, used as the status filename
+#
+# Replaces five near-identical inline jq/sed/xargs pipelines. Requires
+# NETBOX_API and NETBOX_TOKEN in the environment.
+set -euo pipefail
+
+: "${NETBOX_API:?NETBOX_API is required}"
+: "${NETBOX_TOKEN:?NETBOX_TOKEN is required}"
+
+# The single source of truth for the redirector variants.
+# key | netbox tag | download-path custom field | fallback path | reference artifact | check type
+variants=$(
+	cat <<-'TSV'
+		debsbeta	debs-beta	download_path_debs	beta	beta	dists
+		debs	debs	download_path_debs	apt	apt	dists
+		images	images	download_path_images	dl	dl	torrents
+		archive	archive	download_path_images	archive	archive	torrents
+		cache	cache	download_path_cache	cache	cache	noop
+	TSV
+)
+
+nodes='[]'
+while IFS=$'\t' read -r key tag field fallback reference check; do
+	[[ -z "${key}" ]] && continue
+
+	resp=$(curl -fsS --retry 3 --retry-delay 5 --retry-connrefused \
+		-H "Authorization: Token ${NETBOX_TOKEN}" \
+		-H "Accept: application/json" \
+		"${NETBOX_API}/virtualization/virtual-machines/?limit=500&name__empty=false&status=active&tag=${tag}")
+
+	# One clean jq pass per variant: server = name + "/" + download path (the
+	# custom field, or the fallback when it's null/absent).
+	part=$(jq -c \
+		--arg key "${key}" --arg ref "${reference}" --arg check "${check}" \
+		--arg field "${field}" --arg fb "${fallback}" '
+		[ .results[]
+		  | { key:       $key,
+		      reference: $ref,
+		      check:     $check,
+		      server:    (.name + "/" + (.custom_fields[$field] // $fb)),
+		      id:        (.id | tostring) } ]' <<<"${resp}")
+
+	nodes=$(jq -cn --argjson a "${nodes}" --argjson b "${part}" '$a + $b')
+done <<<"${variants}"
+
+echo "${nodes}"

--- a/scripts/redirector/summarize.sh
+++ b/scripts/redirector/summarize.sh
@@ -36,6 +36,13 @@ for f in "${status_dir}"/*; do
 done
 failover="${failover% }"
 
+# An empty pool would generate a redirector config with nowhere to send traffic.
+# Fail the step instead: the previously published config stays live.
+if [[ -z "${failover}" ]]; then
+	echo "summarize: no in-sync mirrors found in '${status_dir}' - refusing to publish an empty failover pool" >&2
+	exit 1
+fi
+
 {
 	echo "failoverserver=${failover}"
 	echo "reloadKey=$(openssl rand -hex 16)"

--- a/scripts/redirector/summarize.sh
+++ b/scripts/redirector/summarize.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Aggregate the per-server status files for one variant:
+#   - append "Not in sync" / "Timeouts" lists to the job step summary
+#   - export failoverserver (space-joined ids of in-sync mirrors) and a fresh
+#     reloadKey to GITHUB_ENV for the redirector-config step
+#
+# Usage: summarize.sh [status-dir]   (default: status)
+set -uo pipefail
+
+status_dir="${1:-status}"
+summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+# status files whose first line is exactly this state; print their 2nd line (server)
+list_state() {
+	local state="$1"
+	local f
+	for f in "${status_dir}"/*; do
+		[[ -f "${f}" ]] || continue
+		[[ "$(sed -n '1p' "${f}")" == "${state}" ]] && sed -n '2p' "${f}"
+	done
+}
+
+{
+	echo "# Not in sync"
+	list_state "not_in_sync"
+	echo "# Timeouts"
+	list_state "timeout"
+} >> "${summary}"
+
+# Failover pool = ids of mirrors reported in sync (first line == "true").
+failover=""
+for f in "${status_dir}"/*; do
+	[[ -f "${f}" ]] || continue
+	[[ "$(sed -n '1p' "${f}")" == "true" ]] && failover+="$(basename "${f}") "
+done
+failover="${failover% }"
+
+{
+	echo "failoverserver=${failover}"
+	echo "reloadKey=$(openssl rand -hex 16)"
+} >> "${GITHUB_ENV:-/dev/stdout}"


### PR DESCRIPTION
## Why

The **Infrastructure: Update CDN redirector** workflow was **~720 lines of copy-paste** — five near-identical NetBox *index* jobs, five *check* jobs and five *redirector* blocks, one per variant (`debs-beta`, `debs`, `images`, `archive`, `cache`). It's also flaky: [this run](https://github.com/armbian/armbian.github.io/actions/runs/32035380064) only went green on **attempt 2** (transient lftp/API timeouts).

## What

Make it **data-driven** and move logic into small, testable scripts:

| Script | Replaces |
|---|---|
| `scripts/redirector/netbox-mirrors.sh` | 5× inline `jq \| sed \| xargs \| sed \| sed \| jq` chains → one clean `jq` per variant, emitting a single combined matrix |
| `scripts/redirector/check-mirror.sh` | 5× copy-pasted mirror+diff+classify blocks |
| `scripts/redirector/summarize.sh` | 5× copy-pasted status-grep/failover blocks |

Jobs collapse via matrices: **5 index jobs → 1**, **5 check jobs → 1**, **5 redirector blocks → 1**. Workflow **723 → 279 lines** (net −604/+331 incl. scripts).

## Bugs fixed along the way

1. **`exit_status` used uninitialised** and only some variants set it (`debs-beta` used `|| true`). The `elif [[ "${exit_status}" -eq 0 ]]` then evaluated an empty var, so **out-of-sync / timeout mirrors were silently dropped**, and `debs-beta` effectively always reported "in sync". Now every variant classifies identically.
2. **`debs-beta` diffed against the wrong reference dir** (it downloaded to `debs-beta/` but `diff`ed `compare` vs `debs`, which didn't exist) — so beta mirrors were never really compared. Reference dir is now normalised for all variants.
3. **Resilience:** the lftp reference pull retries (3×), and every `run` block uses `set -euo pipefail`.

## ⚠️ Behaviour change to review before merge

- **Status artifacts renamed** to `mirror-status-<key>-<id>` (keys: `debsbeta`/`debs`/`images`/`archive`/`cache`). The old stable-debs collection glob `debs*` also swept in **beta** mirrors; that no longer happens — **stable and beta failover pools are now separate** (which matches the NetBox tags). If mixing was intentional, say so and I'll restore it.
- `make-yaml-redirector` is invoked via a matrix with a with/without-`port` pair of steps (debs has no explicit port, as before).

## Validation

- `bash -n` clean on all three scripts; `netbox-mirrors.sh` jq and `summarize.sh` verified against sample data locally.
- Workflow YAML parses.

Because this drives **production CDN routing**, please review the behaviour-change note and ideally **`workflow_dispatch` it once from this branch** to compare the generated `data/` YAMLs before merging.