### PR TITLE
generate_targets: update artifact/image runner mappings

### DIFF
--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -725,17 +725,17 @@ armbian-gha: &armbian-gha
     by-name:
       kernel: [ "self-hosted", "Linux", "alfa" ]
       uboot: [ "self-hosted", "Linux", "fast", "X64" ]
-      armbian-bsp-cli: [ "X64" ]
+      armbian-bsp-cli: [ "self-hosted", "Linux", "fast", "X64" ]
     by-name-and-arch:
       rootfs-armhf: [ "ubuntu-latest" ]
-      rootfs-arm64: [ "ubuntu-24.04-arm" ]
+      rootfs-arm64: [ "self-hosted", "Linux", 'images', 'ARM64' ]
       rootfs-amd64: [ "self-hosted", "Linux", "X64" ]
-      rootfs-riscv64: [ "ubuntu-latest" ]
+      rootfs-riscv64: [ "ubuntu-24.04-riscv" ]
       rootfs-loong64: [ "self-hosted", "Linux", "X64" ]
       image-armhf: [ "self-hosted", "Linux", 'images', 'X64' ]
       image-arm64: [ "self-hosted", "Linux", 'images', 'ARM64' ]
       image-amd64: [ "self-hosted", "Linux", 'images', "X64" ]
-      image-riscv64: [ "self-hosted", "Linux", 'images', "X64" ]
+      image-riscv64: [ "ubuntu-24.04-riscv" ]
       image-loong64: [ "self-hosted", "Linux", 'images', "X64" ]
 
 lists:


### PR DESCRIPTION
Updates the `runners:` map in `generate_targets.py` (emitted into every generated targets YAML):

| Name | Before | After |
|---|---|---|
| `armbian-bsp-cli` | `[ "X64" ]` | `[ "self-hosted", "Linux", "fast", "X64" ]` (same class as `uboot`) |
| `rootfs-arm64` | `[ "ubuntu-24.04-arm" ]` | `[ "self-hosted", "Linux", "images", "ARM64" ]` |
| `rootfs-riscv64` | `[ "ubuntu-latest" ]` | `[ "ubuntu-24.04-riscv" ]` (native riscv) |
| `image-riscv64` | `[ "self-hosted", "Linux", "images", "X64" ]` | `[ "ubuntu-24.04-riscv" ]` (native riscv) |

`py_compile` clean (changes are inside the YAML-template string).