### PR TITLE
repository update: ingest base-files into the package storage

### DIFF
--- a/.github/workflows/infrastructure-repository-update.yml
+++ b/.github/workflows/infrastructure-repository-update.yml
@@ -178,6 +178,35 @@ jobs:
               ;;
           esac
 
+          # Always sync base-files, whatever the target was.
+          #
+          # armbian/ci builds these in their own pipeline (build-base-files.yml,
+          # uploaded to incoming/base-files/) because they must publish even when
+          # a package build did not run - see armbian/build#9476. Nothing used to
+          # consume that directory: "base-files/" fell through to the no-op *)
+          # branch, so the debs piled up in incoming and never reached a
+          # repository. Copy them into STORAGE_PATH, which is what repo.sh reads
+          # (INPUT_DIR="${STORAGE_PATH}/${REPO_NAME}").
+          #
+          # Copied, not moved: unlike incoming/cron these are small, versioned,
+          # and cheap to re-send, and keeping them means a failed run later in the
+          # pipeline cannot lose them. rsync skips what is already identical.
+          for BF_REPO in debs debs-beta; do
+            if [ -d "${INCOMING_PATH}/base-files/${BF_REPO}" ]; then
+              echo "## Copy base-files ${BF_REPO}" >> "$GITHUB_STEP_SUMMARY"
+              rsync -av \
+                --include='*/' \
+                --include='*.deb' \
+                --exclude='*' \
+                --omit-dir-times --no-perms --no-group \
+                "${INCOMING_PATH}/base-files/${BF_REPO}/" "${STORAGE_PATH}/${BF_REPO}/" \
+                2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || \
+                echo "Warning: Some files/attrs were not transferred (code 23)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "## No base-files/${BF_REPO} in incoming, skipping" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
           # Always sync external
           if [ -d "${INCOMING_PATH}/external/debs" ]; then
               echo "## Copy external debs "

--- a/.github/workflows/infrastructure-repository-update.yml
+++ b/.github/workflows/infrastructure-repository-update.yml
@@ -200,8 +200,25 @@ jobs:
                 --exclude='*' \
                 --omit-dir-times --no-perms --no-group \
                 "${INCOMING_PATH}/base-files/${BF_REPO}/" "${STORAGE_PATH}/${BF_REPO}/" \
-                2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || \
-                echo "Warning: Some files/attrs were not transferred (code 23)" >> "$GITHUB_STEP_SUMMARY"
+                2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+              # PIPESTATUS, not $?: the pipe through tee would otherwise report
+              # tee's status and hide every rsync failure. 23 is expected here -
+              # --no-perms/--no-group on the shared-group storage means some
+              # attributes legitimately do not transfer. Anything else is real,
+              # and must stop the run: update-repository would happily publish a
+              # storage tree that is missing these packages.
+              BF_RC=${PIPESTATUS[0]}
+              case "${BF_RC}" in
+                0) ;;
+                23)
+                  echo "Warning: some files/attrs were not transferred (rsync 23)" >> "$GITHUB_STEP_SUMMARY"
+                  ;;
+                *)
+                  echo "::error::rsync of base-files/${BF_REPO} failed (rsync exit ${BF_RC})"
+                  echo "**rsync of base-files/${BF_REPO} failed (exit ${BF_RC})**" >> "$GITHUB_STEP_SUMMARY"
+                  exit 1
+                  ;;
+              esac
             else
               echo "## No base-files/${BF_REPO} in incoming, skipping" >> "$GITHUB_STEP_SUMMARY"
             fi

--- a/.github/workflows/infrastructure-repository-update.yml
+++ b/.github/workflows/infrastructure-repository-update.yml
@@ -188,13 +188,16 @@ jobs:
           # repository. Copy them into STORAGE_PATH, which is what repo.sh reads
           # (INPUT_DIR="${STORAGE_PATH}/${REPO_NAME}").
           #
-          # Copied, not moved: unlike incoming/cron these are small, versioned,
-          # and cheap to re-send, and keeping them means a failed run later in the
-          # pipeline cannot lose them. rsync skips what is already identical.
+          # Moved, not copied: incoming is a drop box, so what has been taken
+          # into storage is removed, the same way incoming/cron is. The move is
+          # done with --remove-source-files rather than a following rm -rf, so
+          # rsync deletes exactly the files it confirmed on the receiving side -
+          # a partial transfer (exit 23) leaves whatever did not land in place
+          # for the next run instead of dropping it.
           for BF_REPO in debs debs-beta; do
             if [ -d "${INCOMING_PATH}/base-files/${BF_REPO}" ]; then
               echo "## Copy base-files ${BF_REPO}" >> "$GITHUB_STEP_SUMMARY"
-              rsync -av \
+              rsync -av --remove-source-files \
                 --include='*/' \
                 --include='*.deb' \
                 --exclude='*' \
@@ -219,10 +222,16 @@ jobs:
                   exit 1
                   ;;
               esac
+              # --remove-source-files only removes files; clear the directories
+              # it emptied, and the per-repo dir itself once it is empty.
+              find "${INCOMING_PATH}/base-files/${BF_REPO}" -type d -empty -delete
             else
               echo "## No base-files/${BF_REPO} in incoming, skipping" >> "$GITHUB_STEP_SUMMARY"
             fi
           done
+          # Drop the now-empty drop box. Left alone if anything remains, so a
+          # partial transfer stays visible for the next run.
+          rmdir "${INCOMING_PATH}/base-files" 2>/dev/null || true
 
           # Always sync external
           if [ -d "${INCOMING_PATH}/external/debs" ]; then

--- a/.github/workflows/infrastructure-repository-update.yml
+++ b/.github/workflows/infrastructure-repository-update.yml
@@ -178,15 +178,22 @@ jobs:
               ;;
           esac
 
-          # Always sync base-files, whatever the target was.
+          # Always ingest the release-generic packages, whatever the target was.
           #
-          # armbian/ci builds these in their own pipeline (build-base-files.yml,
-          # uploaded to incoming/base-files/) because they must publish even when
-          # a package build did not run - see armbian/build#9476. Nothing used to
-          # consume that directory: "base-files/" fell through to the no-op *)
-          # branch, so the debs piled up in incoming and never reached a
-          # repository. Copy them into STORAGE_PATH, which is what repo.sh reads
-          # (INPUT_DIR="${STORAGE_PATH}/${REPO_NAME}").
+          # armbian/ci builds these in their own pipeline and uploads them to
+          # incoming/base-files/ - decoupled so they publish even when a package
+          # build did not run (armbian/build#9476). Nothing used to consume that
+          # directory: the target fell through to the no-op *) branch, so the
+          # debs piled up in incoming and never reached a repository.
+          #
+          # The drop box carries more than base-files. Everything the general
+          # packages build produces lands here and all of it belongs in the
+          # repository - published today as base-files, armbian-firmware,
+          # armbian-firmware-full, armbian-plymouth-theme, armbian-zsh,
+          # fake-ubuntu-advantage-tools and armbian-bsp-cli-<board>. So this
+          # matches on *.deb only: no package list to keep in sync, and a new
+          # generic package needs no change here. repo.sh decides which
+          # component each one belongs to.
           #
           # Moved, not copied: incoming is a drop box, so what has been taken
           # into storage is removed, the same way incoming/cron is. The move is
@@ -194,44 +201,59 @@ jobs:
           # rsync deletes exactly the files it confirmed on the receiving side -
           # a partial transfer (exit 23) leaves whatever did not land in place
           # for the next run instead of dropping it.
-          for BF_REPO in debs debs-beta; do
-            if [ -d "${INCOMING_PATH}/base-files/${BF_REPO}" ]; then
-              echo "## Copy base-files ${BF_REPO}" >> "$GITHUB_STEP_SUMMARY"
-              rsync -av --remove-source-files \
-                --include='*/' \
-                --include='*.deb' \
-                --exclude='*' \
-                --omit-dir-times --no-perms --no-group \
-                "${INCOMING_PATH}/base-files/${BF_REPO}/" "${STORAGE_PATH}/${BF_REPO}/" \
-                2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
-              # PIPESTATUS, not $?: the pipe through tee would otherwise report
-              # tee's status and hide every rsync failure. 23 is expected here -
-              # --no-perms/--no-group on the shared-group storage means some
-              # attributes legitimately do not transfer. Anything else is real,
-              # and must stop the run: update-repository would happily publish a
-              # storage tree that is missing these packages.
-              BF_RC=${PIPESTATUS[0]}
-              case "${BF_RC}" in
-                0) ;;
-                23)
-                  echo "Warning: some files/attrs were not transferred (rsync 23)" >> "$GITHUB_STEP_SUMMARY"
-                  ;;
-                *)
-                  echo "::error::rsync of base-files/${BF_REPO} failed (rsync exit ${BF_RC})"
-                  echo "**rsync of base-files/${BF_REPO} failed (exit ${BF_RC})**" >> "$GITHUB_STEP_SUMMARY"
-                  exit 1
-                  ;;
-              esac
-              # --remove-source-files only removes files; clear the directories
-              # it emptied, and the per-repo dir itself once it is empty.
-              find "${INCOMING_PATH}/base-files/${BF_REPO}" -type d -empty -delete
-            else
-              echo "## No base-files/${BF_REPO} in incoming, skipping" >> "$GITHUB_STEP_SUMMARY"
-            fi
+          #
+          # Only the generic packages move wholesale. kernel, linux-dtb,
+          # linux-libc-dev and u-boot are deliberately NOT in here: there is one
+          # of each per (linuxfamily, branch) and per (board, branch), so which
+          # of them belong in the repository is a selection, not a sweep.
+          # scripts/copy-kernel-packages.sh already does that selection
+          # (SELECT / UBOOT_SELECT / INCLUDE_LIBC_DEV / COPY_UBOOT, deduplicating
+          # against image-info.json); driving it from a config file is the next
+          # step, and belongs in the per-target branches above.
+          #
+          # Add another drop box by naming it here.
+          GENERIC_INCOMING="base-files"
+
+          for GP_DIR in ${GENERIC_INCOMING}; do
+            for GP_REPO in debs debs-beta; do
+              if [ -d "${INCOMING_PATH}/${GP_DIR}/${GP_REPO}" ]; then
+                echo "## Move ${GP_DIR}/${GP_REPO} into storage" >> "$GITHUB_STEP_SUMMARY"
+                rsync -av --remove-source-files \
+                  --include='*/' \
+                  --include='*.deb' \
+                  --exclude='*' \
+                  --omit-dir-times --no-perms --no-group \
+                  "${INCOMING_PATH}/${GP_DIR}/${GP_REPO}/" "${STORAGE_PATH}/${GP_REPO}/" \
+                  2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+                # PIPESTATUS, not $?: the pipe through tee would otherwise report
+                # tee's status and hide every rsync failure. 23 is expected here -
+                # --no-perms/--no-group on the shared-group storage means some
+                # attributes legitimately do not transfer. Anything else is real,
+                # and must stop the run: update-repository would happily publish
+                # a storage tree that is missing these packages.
+                GP_RC=${PIPESTATUS[0]}
+                case "${GP_RC}" in
+                  0) ;;
+                  23)
+                    echo "Warning: some files/attrs were not transferred (rsync 23)" >> "$GITHUB_STEP_SUMMARY"
+                    ;;
+                  *)
+                    echo "::error::rsync of ${GP_DIR}/${GP_REPO} failed (rsync exit ${GP_RC})"
+                    echo "**rsync of ${GP_DIR}/${GP_REPO} failed (exit ${GP_RC})**" >> "$GITHUB_STEP_SUMMARY"
+                    exit 1
+                    ;;
+                esac
+                # --remove-source-files only removes files; clear the directories
+                # it emptied, and the per-repo dir itself once it is empty.
+                find "${INCOMING_PATH}/${GP_DIR}/${GP_REPO}" -type d -empty -delete
+              else
+                echo "## No ${GP_DIR}/${GP_REPO} in incoming, skipping" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done
+            # Drop the now-empty drop box. Left alone if anything remains, so a
+            # partial transfer stays visible for the next run.
+            rmdir "${INCOMING_PATH}/${GP_DIR}" 2>/dev/null || true
           done
-          # Drop the now-empty drop box. Left alone if anything remains, so a
-          # partial transfer stays visible for the next run.
-          rmdir "${INCOMING_PATH}/base-files" 2>/dev/null || true
 
           # Always sync external
           if [ -d "${INCOMING_PATH}/external/debs" ]; then


### PR DESCRIPTION
One half of chaining the weekly stable build into the repository update (armbian/ci counterpart: see below).

## Problem

armbian/ci builds base-files in a separate pipeline (`build-base-files.yml`) and uploads them to `incoming/base-files/`, deliberately decoupled so they publish even when no package build ran — armbian/build#9476.

Nothing consumes that directory. The `Copy operations` case handles `cron/` and falls through to a no-op `*)` for everything else, `base-files/` included. The debs just accumulate:

```
drwxrwsr-x 3 base-files   Aug 14      <- never ingested
drwxrwsr-x 3 community    Aug 14      <- never ingested
drwxrwsr-x 3 cron         Aug 18      <- the only consumed target
drwxrwsr-x 3 images       Aug 17      <- never ingested
drwxrwsr-x 3 nightly      Aug 10      <- never ingested
drwxrwsr-x 3 stable       Aug  9      <- never ingested
```

`cron` is recent precisely because it is the only branch that does real work and deletes its source afterwards.

## Change

Copy `incoming/base-files/{debs,debs-beta}` into `STORAGE_PATH` — the directory `repo.sh` reads (`INPUT_DIR="\${STORAGE_PATH}/\${REPO_NAME}"`) — on **every** run, whatever target triggered it. Same treatment external packages already get.

Copied, not moved: these are small and versioned, rsync skips identical files, and keeping the source means a failure later in the pipeline can't lose them.

## Scope

Only base-files. `stable/`, `nightly/`, `community/` and `apps/` are still unwired — including the `stable/` branch, which currently runs `copy-kernel-packages.sh` in `DRY_RUN=true` against `incoming/nightly/debs-beta/` writing to `/tmp/x`. Those need a policy decision per target and are deliberately left for a separate change.