### PR TITLE
generate_targets: assemble riscv64 images on X64 runners, not native riscv

### DIFF
--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -735,7 +735,7 @@ armbian-gha: &armbian-gha
       image-armhf: [ "self-hosted", "Linux", 'images', 'X64' ]
       image-arm64: [ "self-hosted", "Linux", 'images', 'ARM64' ]
       image-amd64: [ "self-hosted", "Linux", 'images', "X64" ]
-      image-riscv64: [ "ubuntu-24.04-riscv" ]
+      image-riscv64: [ "self-hosted", "Linux", 'images', "X64" ]
       image-loong64: [ "self-hosted", "Linux", 'images', "X64" ]
 
 lists:


### PR DESCRIPTION
## Problem

"Build Standard Support Images" fails assembling riscv64 images (K3picoitx legacy 6.18.y) on the native `rise-riscv-runner-*` (`ubuntu-24.04-riscv`) runners:

```
ls: cannot access '/dev/loop0p1': No such file or directory
Command failed 5 times, giving up [ check_loop_device_internal /dev/loop0p1 ]
error! Device node does not exist after 5 tries.  (error 43)
```

The partition table is created and `lsblk` **sees** `loop0p1`, but the native RISC-V runners never populate the `/dev/loop0p1` device node, so `prepare_partitions` → `check_loop_device` times out.

## Fix

Route `image-riscv64` to the X64 `images` runners — matching `image-loong64`, `image-arm64`, and `image-amd64`. Image assembly is cross-arch (qemu-user-static handles the chroot steps), so it doesn't need native riscv64 hardware:

```diff
-      image-riscv64: [ "ubuntu-24.04-riscv" ]
+      image-riscv64: [ "self-hosted", "Linux", 'images', "X64" ]
```

`rootfs-riscv64` still builds natively on the RISC-V runners; only the image-assembly step moves.