### PR TITLE
images json: promote an image in .iso as well as .img.xz

### DIFF
--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -510,9 +510,30 @@ get_download_repository() {
 # -----------------------------------------------------------------------------
 EXPOSED_MAP_FILE="${OS_DIR}/exposed.map"
 
+# exposed.map lists images by their .img.xz name, so only the .xz can ever be
+# promoted - which is why none of the ISOs on the download pages are flagged,
+# even when the same image is recommended.
+#
+# Compare stems instead: drop the format suffix from both the pattern and the
+# candidate. Only .img.xz and .iso are stripped, so those two are the formats a
+# single exposed.map entry can promote; .img.qcow2, .hyperv.zip.xz and the
+# variant-specific ones (oowow, recovery, fip...) keep their suffix, fail the
+# anchored match, and stay unpromoted unless someone lists them deliberately.
+#
+# The suffix is also what terminates these unanchored patterns, so removing it
+# without anchoring would let '..._minimal' match '..._minimal_something' -
+# hence the '$' the stripped patterns end with.
+IMAGE_FORMAT_SUFFIX_RE='\.(img\.xz|iso)$'
+
+EXPOSED_MAP_MATCH_FILE="$(mktemp)"
+trap '{ rm -f -- "$EXPOSED_MAP_MATCH_FILE"; }' EXIT
+sed -E "s#${IMAGE_FORMAT_SUFFIX_RE}#\$#" "$EXPOSED_MAP_FILE" > "$EXPOSED_MAP_MATCH_FILE"
+
 is_promoted_candidate() {
   local candidate="$1"
-  grep -Eq -f "$EXPOSED_MAP_FILE" <<<"$candidate"
+  # strip the format suffix so the stem is what gets matched
+  candidate="$(sed -E "s#${IMAGE_FORMAT_SUFFIX_RE}##" <<<"$candidate")"
+  grep -Eq -f "$EXPOSED_MAP_MATCH_FILE" <<<"$candidate"
 }
 
 is_promoted() {


### PR DESCRIPTION
Found while looking at why [uefi-x86](https://armbian.com/boards/uefi-x86) shows what it shows.

## Problem

`exposed.map` — the allowlist behind the **recommended** flag — lists images by their `.img.xz` name, and `is_promoted_candidate()` greps that pattern against the file name as written. All **216** patterns end in `.xz`, so nothing else is promotable.

The index currently holds **26 ISOs**, none of which can ever be flagged, even when the identical image in `.img.xz` is recommended.

## Change

Match on the stem: strip the format suffix from both the pattern and the candidate.

```bash
IMAGE_FORMAT_SUFFIX_RE='\.(img\.xz|iso)$'
```

Only `.img.xz` and `.iso` are stripped, so those are the two formats a single entry promotes. `.img.qcow2`, `.hyperv.zip.xz` and the variant suffixes (`oowow`, `recovery`, `fip`…) keep theirs, fail the anchored match and stay unpromoted unless someone lists them deliberately.

The suffix was also acting as the terminator for these unanchored patterns, so the stripped patterns are anchored with `$`; without that, `..._minimal` would start matching `..._minimal_something`.

## Verification

Against the two real uefi-x86 patterns from `exposed.map`:

| file | before | after |
|---|---|---|
| `…_trixie_current_…_minimal.img.xz` | ✅ | ✅ |
| `…_trixie_current_…_minimal.iso` | ❌ | **✅** |
| `…_trixie_current_…_minimal.img.qcow2.xz` | ❌ | ❌ |
| `…_trixie_current_…_minimal.hyperv.zip.xz` | ❌ | ❌ |
| `…_trixie_current_…_minimal.oowow.img.xz` | ❌ | ❌ |
| `…_minimal_extra.img.xz` (over-match guard) | ❌ | ❌ |

## Separate, not fixed here

uefi-x86 shows only one recommended image because the second pattern is stale:

```
uefi-x86/archive/…Uefi-x86_noble_current_…_gnome_desktop.img.xz
```

There is no `noble current gnome_desktop` image any more — desktops moved to `resolute`. That is an `exposed.map` edit in armbian/os, and ties into dropping noble.