### PR TITLE
release-targets: ship generic UEFI apps as .iso, not raw

### DIFF
--- a/release-targets/targets-release-apps.blacklist
+++ b/release-targets/targets-release-apps.blacklist
@@ -4,3 +4,9 @@ oneplus-kebab
 xiaomi-elish
 beaglebadge
 pocketbeagle2
+# The generic UEFI virtual targets are distributed as installable .iso images,
+# not raw board images. The apps auto-section can't set image-output-iso (it
+# emits boards without per-board extensions), so these two are excluded here
+# and re-added as .iso app targets in targets-release-apps.manual.
+uefi-x86
+uefi-arm64

--- a/release-targets/targets-release-apps.manual
+++ b/release-targets/targets-release-apps.manual
@@ -1,0 +1,57 @@
+# Manual target additions for apps builds.
+# This content is appended to the auto-generated targets-release-apps.yaml.
+#
+# The generic UEFI virtual targets (uefi-x86, uefi-arm64) are blacklisted from
+# the auto apps section - see targets-release-apps.blacklist. They're shipped as
+# installable .iso images rather than raw board images, which the auto section
+# can't express (it emits boards without per-board extensions). The same three
+# app images (Home Assistant, OMV, Kali) are re-created for them here with the
+# image-output-iso extension enabled. Branch: current (their KERNEL_TEST_TARGET).
+
+# Home Assistant - UEFI, .iso
+apps-ha-iso:
+  enabled: yes
+  configs: [ armbian-apps ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: DEBIAN
+    BUILD_MINIMAL: "no"
+    BUILD_DESKTOP: "no"
+    ENABLE_EXTENSIONS: "applications-ha,image-output-iso"
+  items:
+    - { BOARD: uefi-arm64, BRANCH: current }
+    - { BOARD: uefi-x86, BRANCH: current }
+
+# OpenMediaVault - UEFI, .iso
+apps-omv-iso:
+  enabled: yes
+  configs: [ armbian-apps ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: DEBIAN
+    BUILD_MINIMAL: "yes"
+    BUILD_DESKTOP: "no"
+    ENABLE_EXTENSIONS: "applications-omv,image-output-iso"
+  items:
+    - { BOARD: uefi-arm64, BRANCH: current }
+    - { BOARD: uefi-x86, BRANCH: current }
+
+# Kali (Debian sid) - UEFI, .iso
+apps-kali-iso:
+  enabled: yes
+  configs: [ armbian-apps ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: sid
+    BUILD_MINIMAL: "no"
+    BUILD_DESKTOP: "no"
+    ENABLE_EXTENSIONS: "applications-kali,image-output-iso"
+  items:
+    - { BOARD: uefi-arm64, BRANCH: current }
+    - { BOARD: uefi-x86, BRANCH: current }


### PR DESCRIPTION
The `apps` release targets are fully auto-generated: `generate_targets.py`
emits every conf/wip board into the `apps-builds` anchor **without
per-board extensions** (`include_extensions=False`), so there's no hook to
give the generic UEFI virtual targets (`uefi-x86`, `uefi-arm64`) the
`image-output-iso` extension. They therefore ship as raw board images
instead of the installable **`.iso`** they should be.

Fix, mirroring the existing `targets-release-standard-support.manual`
pattern:

- **`targets-release-apps.blacklist`** — add `uefi-x86` and `uefi-arm64`,
  removing them from the auto `apps-builds` list (and thus from the raw
  `apps-ha` / `apps-omv` / `apps-kali` targets).
- **`targets-release-apps.manual`** (new) — re-add the same three app
  images for those two boards as `apps-ha-iso` / `apps-omv-iso` /
  `apps-kali-iso`, each with `image-output-iso` appended to the app
  extension, on **`current`** (their `KERNEL_TEST_TARGET`).

### Verification

Ran the generator against the live inventory:

```
curl -L -o image-info.json https://github.armbian.com/image-info.json
python3 scripts/generate_targets.py image-info.json release-targets/
```

- `apps: 171 boards after blacklist` (8 blacklisted, +2).
- `uefi-x86` / `uefi-arm64` no longer appear in the auto `apps-builds` section.
- `apps-ha-iso` / `apps-omv-iso` / `apps-kali-iso` are emitted with
  `ENABLE_EXTENSIONS: "applications-<app>,image-output-iso"` and both boards
  on `current`.
- The full `targets-release-apps.yaml` parses as YAML with all anchors resolved.

### Note

Only `uefi-x86` and `uefi-arm64` are converted. `uefi-arm64-dt` (the
separate device-tree arm64 board) is left in the auto apps section as-is —
say the word if it should get the same `.iso` treatment.