### PR TITLE
generate-armbian-images-json: fix empty nightly (ci) feed

### DIFF
--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -651,14 +651,29 @@ for repo in community ci distribution; do
     # one of those stable markers, so `gh release view` with no tag reads a
     # 0-asset release and the nightly feed comes out EMPTY. Resolve the highest
     # promoted (non-pre-release) -trunk.N tag that actually has assets instead.
+    #
+    # The --jq filter runs per page, so it only ever *filters* - it prints every
+    # matching tag and the ordering is done once, afterwards, over all pages.
+    # Picking a maximum inside the filter would yield one winner per page.
+    #
+    # sort -V, not the trunk ordinal: comparing only N makes 26.10.0-trunk.100
+    # look newer than 26.11.0-trunk.19. Version sort compares major, minor,
+    # patch and then the ordinal, matching the -v:refname ordering used
+    # elsewhere. The pattern is anchored so only exact X.Y.Z-trunk.N qualifies.
     tag="$(gh api --paginate "repos/armbian/$repo/releases" --jq '
-      [ .[] | select((.tag_name|test("-trunk[.]")) and (.prerelease==false) and (.assets|length>0)) ]
-      | max_by(.tag_name | capture("-trunk[.](?<n>[0-9]+)").n | tonumber) | .tag_name')"
+      .[]
+      | select((.tag_name | test("^[0-9]+[.][0-9]+[.][0-9]+-trunk[.][0-9]+$"))
+               and (.prerelease == false)
+               and ((.assets | length) > 0))
+      | .tag_name' | sort -V | tail -n1)"
     if [[ -z "$tag" ]]; then
-      echo "WARNING: no armbian/$repo -trunk.N release with assets found; nightly feed will be empty" >&2
-    else
-      echo "Nightly feed: using armbian/$repo release $tag" >&2
+      # Falling through would call `gh release view` with no tag, which is the
+      # very thing this block exists to avoid: it resolves to "latest" and can
+      # feed stable assets into the nightly section.
+      echo "WARNING: no armbian/$repo -trunk.N release with assets found; skipping nightly feed" >&2
+      continue
     fi
+    echo "Nightly feed: using armbian/$repo release $tag" >&2
   fi
   gh release view ${tag:+"$tag"} --json assets --repo "github.com/armbian/$repo" |
   jq -r '.assets[]

--- a/scripts/generate-armbian-images-json.sh
+++ b/scripts/generate-armbian-images-json.sh
@@ -644,7 +644,23 @@ awk '
 # distribution -> stable release images
 : >"$tmpdir/bcd.txt"
 for repo in community ci distribution; do
-  gh release view --json assets --repo "github.com/armbian/$repo" |
+  tag=""
+  if [[ "$repo" == "ci" ]]; then
+    # armbian/ci holds X.Y.Z-trunk.N nightlies AND clean X.Y.Z stable version
+    # markers (which carry no image assets). Its GitHub "latest" is frequently
+    # one of those stable markers, so `gh release view` with no tag reads a
+    # 0-asset release and the nightly feed comes out EMPTY. Resolve the highest
+    # promoted (non-pre-release) -trunk.N tag that actually has assets instead.
+    tag="$(gh api --paginate "repos/armbian/$repo/releases" --jq '
+      [ .[] | select((.tag_name|test("-trunk[.]")) and (.prerelease==false) and (.assets|length>0)) ]
+      | max_by(.tag_name | capture("-trunk[.](?<n>[0-9]+)").n | tonumber) | .tag_name')"
+    if [[ -z "$tag" ]]; then
+      echo "WARNING: no armbian/$repo -trunk.N release with assets found; nightly feed will be empty" >&2
+    else
+      echo "Nightly feed: using armbian/$repo release $tag" >&2
+    fi
+  fi
+  gh release view ${tag:+"$tag"} --json assets --repo "github.com/armbian/$repo" |
   jq -r '.assets[]
     | select(.url | test("\\.txt($|\\?)") | not)
     | select(.url | test("\\.(asc|sha|torrent)($|\\?)") | not)


### PR DESCRIPTION
### Problem

`scripts/generate-armbian-images-json.sh` already sources nightlies from
`armbian/ci` (moved from the retired `armbian/os`), but reads it with:

```bash
gh release view --json assets --repo "github.com/armbian/ci"   # no tag
```

`gh release view` with no tag returns GitHub's **"latest"** release.
`armbian/ci` stores clean `X.Y.Z` **stable version markers** (which carry
**no image assets**) next to the `X.Y.Z-trunk.N` nightlies, and that stable
marker is frequently the "latest" — so the call lands on a **0-asset**
release and the **nightly section of `armbian-images.json` comes out empty**.

Today: `gh release view --repo armbian/ci` → **`26.8.3`, 0 assets**.

### Fix

For the `ci` repo only, resolve the **highest promoted (non-pre-release)
`-trunk.N` tag that actually has assets** and read that release explicitly;
`community` and `distribution` keep using GitHub's latest. A `WARNING` is
logged if no trunk-with-assets release is found.

```bash
tag="$(gh api --paginate repos/armbian/ci/releases --jq '
  [ .[] | select((.tag_name|test("-trunk[.]")) and (.prerelease==false) and (.assets|length>0)) ]
  | max_by(.tag_name | capture("-trunk[.](?<n>[0-9]+)").n | tonumber) | .tag_name')"
gh release view ${tag:+"$tag"} --json assets --repo "github.com/armbian/ci" | ...
```

### Verified (live data)

| feed | before | after |
|---|---|---|
| community | 522 | 522 |
| **ci (nightly)** | **0 (empty!)** | **78 → `26.11.0-trunk.19`** |
| distribution | 3 | 3 |

`bash -n` clean, `shellcheck -S error` clean.

### Note

This is the canonical generator for `github.armbian.com/armbian-images.json`.
The same `gh release view` (no tag) pattern also lives in
`armbian/os` `webindex-update.yml` (which builds the redirector's
`all-images.json`) — I opened armbian/os#486 for that one; if `webindex-update`
is superseded by this script, that PR can be closed instead.