### PR TITLE
redirector: use download_path_archive for the archive variant

### DIFF
--- a/scripts/redirector/netbox-mirrors.sh
+++ b/scripts/redirector/netbox-mirrors.sh
@@ -27,7 +27,7 @@ variants=$(
 		debsbeta	debs-beta	download_path_debs	beta	beta	dists
 		debs	debs	download_path_debs	apt	apt	dists
 		images	images	download_path_images	dl	dl	torrents
-		archive	archive	download_path_images	archive	archive	torrents
+		archive	archive	download_path_archive	archive	archive	torrents
 		cache	cache	download_path_cache	cache	cache	noop
 	TSV
 )


### PR DESCRIPTION
### Symptom

The CDN-redirector check job (e.g. run
[32571573743](https://github.com/armbian/armbian.github.io/actions/runs/32571573743))
probed **archives at the wrong path** on mirrors that define a distinct
archive alias:

```
au.sbcmirror.org/armbian-dl        ❌  (should be /armbian-archive)
es.sbcmirror.org/armbian-dl        ❌
```

### Cause

In `scripts/redirector/netbox-mirrors.sh`, the variant table's **archive**
row read the NetBox custom field **`download_path_images`** instead of
**`download_path_archive`**:

```diff
- archive   archive   download_path_images    archive   archive   torrents
+ archive   archive   download_path_archive   archive   archive   torrents
```

So archive mirrors inherited the *images* alias (`armbian-dl`) rather than
their own (`armbian-archive`). NetBox has both fields; only the script was
wrong.

### Effect / safety

Mirrors that leave `download_path_archive` **unset** still fall back to the
`archive` path — unchanged (e.g. `sg.sbcmirror.org`, and all the
null-alias mirrors). Only mirrors that set a distinct archive alias are
corrected.

### Verified against live NetBox

```
archive variant:  au.sbcmirror.org/armbian-archive   es.sbcmirror.org/armbian-archive   ✅
images  variant:  au.sbcmirror.org/armbian-dl        es.sbcmirror.org/armbian-dl        (unchanged)
```

`bash -n` clean.