### PR TITLE
nightly: Debian forky minimal with edge kernel for musepipro and k3picoitx

### DIFF
--- a/release-targets/targets-release-nightly.manual
+++ b/release-targets/targets-release-nightly.manual
@@ -61,3 +61,25 @@ minimal-cli-stable-debian-cloud-trixie:
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
+
+# SpacemiT RISC-V, edge kernel on Debian forky.
+#
+# forky is pinned literally rather than using the DEBIAN token: the token
+# resolves to the current stable codename, and the point of this target is to
+# exercise the next Debian alongside the edge kernel.
+#
+# k3picoitx gained its edge branch in armbian/build#10506; without that merged
+# it has only legacy/current and this item resolves to nothing.
+minimal-cli-forky-edge-spacemit:
+  enabled: yes
+  configs: [ armbian-images ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: forky
+    BUILD_MINIMAL: "yes"
+    BUILD_DESKTOP: "no"
+  items:
+    - { BOARD: musepipro, BRANCH: edge }
+    - { BOARD: k3picoitx, BRANCH: edge }


### PR DESCRIPTION
Adds a nightly-only target — standard-support is untouched.

```yaml
minimal-cli-forky-edge-spacemit:
  enabled: yes
  configs: [ armbian-images ]
  build-image: "yes"
  vars:
    RELEASE: forky
    BUILD_MINIMAL: "yes"
    BUILD_DESKTOP: "no"
  items:
    - { BOARD: musepipro, BRANCH: edge }
    - { BOARD: k3picoitx, BRANCH: edge }
```

**`forky` is pinned literally**, not via the `DEBIAN` token — that token resolves to the current stable codename, and the point of this target is to exercise the next Debian alongside the edge kernel.

Verified by running `scripts/generate_targets.py` against the live `image-info.json`: the block lands in `targets-release-nightly.yaml` with both items intact.

## Depends on armbian/build#10506

Branch availability, checked against the live inventory:

| board | branches today |
|---|---|
| musepipro | legacy, current, **edge** ✅ |
| k3picoitx | legacy, current — **no edge** |

`spacemit-k3.conf` had only two `case` arms, so #10506 adds the `edge` one plus `edge` in the board's `KERNEL_TARGET`. Until it merges, the `k3picoitx` item here resolves to nothing — no error, just no image.

That PR also flags two things worth knowing before trusting the k3 edge image: there is no `linux-spacemit-k3-edge.config` yet (it borrows K1's mainline config), and mainline K3 support is unverified — `current` uses a `-riscv-k3.0` Fedora ark fork, which suggests K3 is not upstream. It may build and not boot.