### PR TITLE
release-summary: weekly-only GitHub releases, release-anchored quarterly window

### DIFF
--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -21,7 +21,7 @@ on:
           - monthly
           - quarterly
       publish_release:
-        description: "Publish a GitHub release"
+        description: "Publish a GitHub release (weekly only; monthly and quarterly never do)"
         required: false
         default: "true"
         type: choice
@@ -85,6 +85,23 @@ jobs:
           echo "UNTIL_UTC=$UNTIL_UTC" >> "$GITHUB_ENV"
           echo "SINCE_UTC=$SINCE_UTC" >> "$GITHUB_ENV"
           echo "LABEL=$LABEL" >> "$GITHUB_ENV"
+
+          # Only the weekly digest becomes a GitHub release on armbian/build.
+          #
+          # The quarterly note now lives on docs.armbian.com, which is the only
+          # copy search engines can see -- GitHub serves release pages noindex.
+          # Publishing both left two copies competing, and the GitHub one had to
+          # invent a v<version> tag in armbian/build that exists only in
+          # armbian/ci, then move the "Latest" badge onto it.
+          #
+          # Monthly stops publishing too: it selects the same stable tag as the
+          # quarterly, so whichever ran first won the tag and skipIfReleaseExists
+          # made the other a silent no-op.
+          if [[ "$PERIOD" != "weekly" ]]; then
+            RELEASE_ENABLED=false
+          fi
+          echo "RELEASE_ENABLED=$RELEASE_ENABLED" >> "$GITHUB_ENV"
+          echo "Period ${PERIOD}: GitHub release enabled = ${RELEASE_ENABLED}"
 
       - name: Prepare workspace
         run: mkdir -p out
@@ -599,29 +616,46 @@ jobs:
       # version. Weekly and monthly digests stay on GitHub releases only.
       # ----------------------------------------------------------------------
 
+      - name: "Docs: check out armbian/documentation"
+        if: ${{ env.PERIOD == 'quarterly' }}
+        uses: actions/checkout@v5
+        with:
+          repository: armbian/documentation
+          path: documentation
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: false
+
       - name: "Docs: resolve the release date and the docs version"
         if: ${{ env.PERIOD == 'quarterly' }}
         run: |
           set -euo pipefail
-          # Prefer the release's own publish date so re-runs keep reporting the
-          # original date rather than the date of the re-run.
+          # The date must not move when this is re-run, so it is read from
+          # something dated rather than from the clock. Sources, in order:
           #
-          # gh writes its error body to stdout, so a 404 for a release that does
-          # not exist yet would otherwise land in PUBLISHED and make `date -d`
-          # fail the step. Only accept something shaped like a timestamp; the
-          # fallback below is what an absent release is supposed to reach.
-          PUBLISHED=$(gh api "repos/armbian/build/releases/tags/v${VERSION_OVERRIDE}" \
-            --jq '.published_at' 2>/dev/null || true)
-          if [[ ! "$PUBLISHED" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]; then
-            PUBLISHED=""
-          fi
-          if [[ -n "$PUBLISHED" ]]; then
-            RELEASE_DATE=$(date -u -d "$PUBLISHED" '+%-d %B %Y')
-          else
-            RELEASE_DATE=$(date -u '+%-d %B %Y')
-          fi
-          echo "RELEASE_DATE=$RELEASE_DATE" >> "$GITHUB_ENV"
-          echo "Release date: $RELEASE_DATE"
+          #   1. the page itself, if this quarter has already been published.
+          #      Once a release note is on main its date is a matter of record
+          #      and must not move, whatever later becomes of the tag or the
+          #      release it was first read from. This is what makes the page
+          #      independent of retention in armbian/ci.
+          #   2. the armbian/build release, for quarters published back when
+          #      quarterly still created one, and for any tag a weekly used
+          #   3. the armbian/ci tag the version came from -- the actual cut
+          #      date, and the usual source for a new quarter now that
+          #      quarterly no longer publishes a release. armbian/ci prunes
+          #      old *releases* (see its delete-old-releases.yml) but never
+          #      the tags, so this outlives the release it was cut for.
+          #   4. today, only if all of those are gone
+          #
+          # `commits/<ref>` takes the tag name directly and dereferences an
+          # annotated tag on its own, so this stays one call either way.
+          #
+          # gh writes its error body to stdout, so a 404 lands in the variable
+          # and `date -d` would fail the step under set -e. Accept only
+          # something shaped like a timestamp.
+          iso_or_empty() {
+            [[ "$1" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]] && printf '%s' "$1"
+            return 0
+          }
 
           # Armbian ships one stable per quarter and then patches it. The digest
           # describes the quarter, not the patch, so the docs page is keyed on
@@ -633,6 +667,47 @@ jobs:
           DOCS_VERSION=$(sed -E 's/^([0-9]+\.[0-9]+)\.[0-9]+$/\1/' <<<"$VERSION_OVERRIDE")
           echo "DOCS_VERSION=$DOCS_VERSION" >> "$GITHUB_ENV"
           echo "Docs version: $DOCS_VERSION (from $VERSION_OVERRIDE)"
+
+          PUBLISHED=""
+          DATE_SOURCE=""
+
+          PAGE="documentation/docs/releases/${DOCS_VERSION}.md"
+          if [[ -f "$PAGE" ]]; then
+            PRIOR=$(sed -n 's/^\*Released \(.*\)\*[[:space:]]*$/\1/p' "$PAGE" | head -n1)
+            if [[ -n "$PRIOR" ]]; then
+              RELEASE_DATE="$PRIOR"
+              DATE_SOURCE="the published page, which is now the record"
+            fi
+          fi
+
+          if [[ -z "${RELEASE_DATE:-}" ]]; then
+            PUBLISHED=$(iso_or_empty "$(gh api \
+              "repos/armbian/build/releases/tags/v${VERSION_OVERRIDE}" \
+              --jq '.published_at' 2>/dev/null || true)")
+            DATE_SOURCE="armbian/build release v${VERSION_OVERRIDE}"
+          fi
+
+          if [[ -z "${RELEASE_DATE:-}" && -z "$PUBLISHED" ]]; then
+            PUBLISHED=$(iso_or_empty "$(gh api \
+              "repos/armbian/ci/commits/${VERSION_OVERRIDE}" \
+              --jq '.commit.committer.date' 2>/dev/null || true)")
+            DATE_SOURCE="armbian/ci tag ${VERSION_OVERRIDE}"
+          fi
+
+          if [[ -n "${RELEASE_DATE:-}" ]]; then
+            :
+          elif [[ -z "$PUBLISHED" ]]; then
+            DATE_SOURCE="today: no armbian/build release and no armbian/ci tag"
+            echo "::warning title=Release date::No release or tag found for \
+          ${VERSION_OVERRIDE}; dating the page today, which will move if this \
+          is re-run"
+            RELEASE_DATE=$(LC_ALL=C date -u '+%-d %B %Y')
+          else
+            RELEASE_DATE=$(LC_ALL=C date -u -d "$PUBLISHED" '+%-d %B %Y')
+          fi
+          echo "RELEASE_DATE=$RELEASE_DATE" >> "$GITHUB_ENV"
+          echo "Release date: $RELEASE_DATE (from $DATE_SOURCE)"
+
 
       - name: "Docs: check out this repository for the generator scripts"
         if: ${{ env.PERIOD == 'quarterly' }}
@@ -721,15 +796,6 @@ jobs:
               print(f"description ({len(text)} chars): {text}")
           PY
 
-      - name: "Docs: check out armbian/documentation"
-        if: ${{ env.PERIOD == 'quarterly' }}
-        uses: actions/checkout@v5
-        with:
-          repository: armbian/documentation
-          path: documentation
-          token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: false
-
       - name: "Docs: render the release page"
         if: ${{ env.PERIOD == 'quarterly' }}
         run: |
@@ -774,7 +840,12 @@ jobs:
           title: "releases: Armbian ${{ env.VERSION_OVERRIDE }} release notes"
           body: |
             Generated by [Reporting: Release summary](https://github.com/armbian/armbian.github.io/actions/workflows/reporting-release-summary.yml)
-            from the quarterly digest published as [v${{ env.VERSION_OVERRIDE }}](https://github.com/armbian/build/releases/tag/v${{ env.VERSION_OVERRIDE }}).
+            for Armbian ${{ env.VERSION_OVERRIDE }}, from the pull requests
+            merged across the org in the release window.
+
+            This page is the canonical release note. The quarterly digest is no
+            longer published as a GitHub release, because GitHub serves release
+            pages `noindex` and this one has to be findable.
 
             The narrative body, the change list and the board status changes all
             come from PR metadata and the digest; nothing here is hand-written.

--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -20,6 +20,10 @@ on:
           - weekly
           - monthly
           - quarterly
+      release_date:
+        description: "Release date for the docs page, e.g. '29 May 2026' (default: the day this runs)"
+        required: false
+        default: ""
       publish_release:
         description: "Publish a GitHub release (weekly only; monthly and quarterly never do)"
         required: false
@@ -46,6 +50,7 @@ jobs:
       TZ: ${{ inputs.tz || 'Europe/Ljubljana' }}
       PERIOD: ${{ inputs.period || 'weekly' }}
       RELEASE_ENABLED: ${{ inputs.publish_release || 'true' }}
+      RELEASE_DATE_INPUT: ${{ inputs.release_date || '' }}
 
     steps:
 
@@ -65,6 +70,85 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq pngquant imagemagick
 
+      - name: "Read version from armbian/ci tags (nightly = latest *trunk* tag, else stable)"
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Nightly images now release under armbian/ci, so derive the version
+          # from its tags instead of the old os/{nightly,stable}.json files:
+          # the newest tag with 'trunk' in the name is the nightly version, the
+          # newest without it is stable. -v:refname yields version order, so
+          # 26.8.0-trunk.6 > 26.8.0-trunk.5 and 26.8.0 > its prereleases.
+          TAGS=$(git ls-remote --tags --refs --sort=-v:refname \
+            https://github.com/armbian/ci | sed 's#.*refs/tags/##')
+          if [[ -z "$TAGS" ]]; then
+            echo "::error::No tags found in armbian/ci"
+            exit 1
+          fi
+          if [[ "$PERIOD" == "monthly" || "$PERIOD" == "quarterly" ]]; then
+            VERSION=$(grep -v -- trunk <<<"$TAGS" | head -n1 || true)   # stable
+          else
+            VERSION=$(grep -- trunk <<<"$TAGS" | head -n1 || true)      # nightly
+          fi
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::No matching armbian/ci tag for period=$PERIOD"
+            exit 1
+          fi
+          VERSION="${VERSION#v}"   # downstream re-adds the 'v' prefix
+          echo "Selected ${PERIOD} version from armbian/ci tags: ${VERSION}"
+          echo "VERSION_OVERRIDE=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: "Docs: check out this repository for the generator scripts"
+        if: ${{ env.PERIOD == 'quarterly' }}
+        uses: actions/checkout@v5
+        with:
+          path: self
+          persist-credentials: false
+
+      - name: "Docs: check out armbian/documentation"
+        if: ${{ env.PERIOD == 'quarterly' }}
+        uses: actions/checkout@v5
+        with:
+          repository: armbian/documentation
+          path: documentation
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: false
+
+      - name: "Docs: resolve the release date and the docs version"
+        if: ${{ env.PERIOD == 'quarterly' }}
+        run: |
+          set -euo pipefail
+          # Armbian ships one stable per quarter and then patches it. The digest
+          # describes the quarter, not the patch, so the docs page is keyed on
+          # MAJOR.MINOR: 26.8.1 and a later 26.8.3 rewrite one page on one branch
+          # instead of publishing the same three months twice.
+          #
+          # Strip the patch only when there is one, so a bare "26.8" survives
+          # intact -- ${VERSION_OVERRIDE%.*} would turn it into "26".
+          DOCS_VERSION=$(sed -E 's/^([0-9]+\.[0-9]+)\.[0-9]+$/\1/' <<<"$VERSION_OVERRIDE")
+          echo "DOCS_VERSION=$DOCS_VERSION" >> "$GITHUB_ENV"
+          echo "Docs version: $DOCS_VERSION (from $VERSION_OVERRIDE)"
+
+          # Only quarters published back when quarterly still created a GitHub
+          # release have one to read. gh writes its error body to stdout, so a 404
+          # would otherwise be mistaken for a date; keep only a real timestamp.
+          PUBLISHED=$(gh api "repos/armbian/build/releases/tags/v${VERSION_OVERRIDE}" \
+            --jq '.published_at' 2>/dev/null || true)
+          if [[ ! "$PUBLISHED" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]; then
+            PUBLISHED=""
+          fi
+
+          # Resolves the date and the PR window together, because the window is
+          # anchored to the releases either side of it. See the script for why
+          # neither may be read from the clock once a quarter has been published.
+          python3 self/scripts/resolve-release-window.py \
+            --releases-dir documentation/docs/releases \
+            --docs-version "$DOCS_VERSION" \
+            --release-date "${RELEASE_DATE_INPUT:-}" \
+            --published-at "$PUBLISHED" \
+            | tee -a "$GITHUB_ENV"
+
+
       - name: Compute time window (UTC) from period
         id: when
         shell: bash
@@ -76,14 +160,24 @@ jobs:
             SINCE_UTC="$(date -u -d '1 month ago' +%Y-%m-%dT%H:%M:%SZ)"
             LABEL="Armbian Monthly digest"
           elif [[ "$PERIOD" == "quarterly" ]]; then
-            SINCE_UTC="$(date -u -d '3 months ago' +%Y-%m-%dT%H:%M:%SZ)"
             LABEL="Armbian Quarterly digest"
           else
             SINCE_UTC="$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)"
             LABEL="Armbian Weekly digest"
           fi
-          echo "UNTIL_UTC=$UNTIL_UTC" >> "$GITHUB_ENV"
-          echo "SINCE_UTC=$SINCE_UTC" >> "$GITHUB_ENV"
+
+          # Weekly and monthly are digests of a period, so the clock is the
+          # right source. Quarterly is the record of one release, so its
+          # window was already anchored to the releases either side of it by
+          # the resolver step -- leave those values alone. A clock-based
+          # window slides: regenerating 26.8 three weeks late would drop
+          # three weeks of PRs off the start, PRs that belong to 26.8 and
+          # would then appear in no release note at all, and pull in three
+          # weeks of work belonging to the next quarter.
+          if [[ "$PERIOD" != "quarterly" ]]; then
+            echo "UNTIL_UTC=$UNTIL_UTC" >> "$GITHUB_ENV"
+            echo "SINCE_UTC=$SINCE_UTC" >> "$GITHUB_ENV"
+          fi
           echo "LABEL=$LABEL" >> "$GITHUB_ENV"
 
           # Only the weekly digest becomes a GitHub release on armbian/build.
@@ -200,34 +294,6 @@ jobs:
           name: pr-digest
           path: out/
           if-no-files-found: warn
-
-      - name: "Read version from armbian/ci tags (nightly = latest *trunk* tag, else stable)"
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Nightly images now release under armbian/ci, so derive the version
-          # from its tags instead of the old os/{nightly,stable}.json files:
-          # the newest tag with 'trunk' in the name is the nightly version, the
-          # newest without it is stable. -v:refname yields version order, so
-          # 26.8.0-trunk.6 > 26.8.0-trunk.5 and 26.8.0 > its prereleases.
-          TAGS=$(git ls-remote --tags --refs --sort=-v:refname \
-            https://github.com/armbian/ci | sed 's#.*refs/tags/##')
-          if [[ -z "$TAGS" ]]; then
-            echo "::error::No tags found in armbian/ci"
-            exit 1
-          fi
-          if [[ "$PERIOD" == "monthly" || "$PERIOD" == "quarterly" ]]; then
-            VERSION=$(grep -v -- trunk <<<"$TAGS" | head -n1 || true)   # stable
-          else
-            VERSION=$(grep -- trunk <<<"$TAGS" | head -n1 || true)      # nightly
-          fi
-          if [[ -z "$VERSION" ]]; then
-            echo "::error::No matching armbian/ci tag for period=$PERIOD"
-            exit 1
-          fi
-          VERSION="${VERSION#v}"   # downstream re-adds the 'v' prefix
-          echo "Selected ${PERIOD} version from armbian/ci tags: ${VERSION}"
-          echo "VERSION_OVERRIDE=${VERSION}" >> "$GITHUB_ENV"
 
       - name: "Write a short journalistic intro with AI"
         run: |
@@ -615,106 +681,6 @@ jobs:
       # findable, so the stable release note is mirrored there as one page per
       # version. Weekly and monthly digests stay on GitHub releases only.
       # ----------------------------------------------------------------------
-
-      - name: "Docs: check out armbian/documentation"
-        if: ${{ env.PERIOD == 'quarterly' }}
-        uses: actions/checkout@v5
-        with:
-          repository: armbian/documentation
-          path: documentation
-          token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: false
-
-      - name: "Docs: resolve the release date and the docs version"
-        if: ${{ env.PERIOD == 'quarterly' }}
-        run: |
-          set -euo pipefail
-          # The date must not move when this is re-run, so it is read from
-          # something dated rather than from the clock. Sources, in order:
-          #
-          #   1. the page itself, if this quarter has already been published.
-          #      Once a release note is on main its date is a matter of record
-          #      and must not move, whatever later becomes of the tag or the
-          #      release it was first read from. This is what makes the page
-          #      independent of retention in armbian/ci.
-          #   2. the armbian/build release, for quarters published back when
-          #      quarterly still created one, and for any tag a weekly used
-          #   3. the armbian/ci tag the version came from -- the actual cut
-          #      date, and the usual source for a new quarter now that
-          #      quarterly no longer publishes a release. armbian/ci prunes
-          #      old *releases* (see its delete-old-releases.yml) but never
-          #      the tags, so this outlives the release it was cut for.
-          #   4. today, only if all of those are gone
-          #
-          # `commits/<ref>` takes the tag name directly and dereferences an
-          # annotated tag on its own, so this stays one call either way.
-          #
-          # gh writes its error body to stdout, so a 404 lands in the variable
-          # and `date -d` would fail the step under set -e. Accept only
-          # something shaped like a timestamp.
-          iso_or_empty() {
-            [[ "$1" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]] && printf '%s' "$1"
-            return 0
-          }
-
-          # Armbian ships one stable per quarter and then patches it. The digest
-          # describes the quarter, not the patch, so the docs page is keyed on
-          # MAJOR.MINOR: 26.8.1 and a later 26.8.3 rewrite one page on one
-          # branch instead of publishing the same three months twice.
-          #
-          # Strip the patch only when there is one, so a bare "26.8" survives
-          # intact -- ${VERSION_OVERRIDE%.*} would turn it into "26".
-          DOCS_VERSION=$(sed -E 's/^([0-9]+\.[0-9]+)\.[0-9]+$/\1/' <<<"$VERSION_OVERRIDE")
-          echo "DOCS_VERSION=$DOCS_VERSION" >> "$GITHUB_ENV"
-          echo "Docs version: $DOCS_VERSION (from $VERSION_OVERRIDE)"
-
-          PUBLISHED=""
-          DATE_SOURCE=""
-
-          PAGE="documentation/docs/releases/${DOCS_VERSION}.md"
-          if [[ -f "$PAGE" ]]; then
-            PRIOR=$(sed -n 's/^\*Released \(.*\)\*[[:space:]]*$/\1/p' "$PAGE" | head -n1)
-            if [[ -n "$PRIOR" ]]; then
-              RELEASE_DATE="$PRIOR"
-              DATE_SOURCE="the published page, which is now the record"
-            fi
-          fi
-
-          if [[ -z "${RELEASE_DATE:-}" ]]; then
-            PUBLISHED=$(iso_or_empty "$(gh api \
-              "repos/armbian/build/releases/tags/v${VERSION_OVERRIDE}" \
-              --jq '.published_at' 2>/dev/null || true)")
-            DATE_SOURCE="armbian/build release v${VERSION_OVERRIDE}"
-          fi
-
-          if [[ -z "${RELEASE_DATE:-}" && -z "$PUBLISHED" ]]; then
-            PUBLISHED=$(iso_or_empty "$(gh api \
-              "repos/armbian/ci/commits/${VERSION_OVERRIDE}" \
-              --jq '.commit.committer.date' 2>/dev/null || true)")
-            DATE_SOURCE="armbian/ci tag ${VERSION_OVERRIDE}"
-          fi
-
-          if [[ -n "${RELEASE_DATE:-}" ]]; then
-            :
-          elif [[ -z "$PUBLISHED" ]]; then
-            DATE_SOURCE="today: no armbian/build release and no armbian/ci tag"
-            echo "::warning title=Release date::No release or tag found for \
-          ${VERSION_OVERRIDE}; dating the page today, which will move if this \
-          is re-run"
-            RELEASE_DATE=$(LC_ALL=C date -u '+%-d %B %Y')
-          else
-            RELEASE_DATE=$(LC_ALL=C date -u -d "$PUBLISHED" '+%-d %B %Y')
-          fi
-          echo "RELEASE_DATE=$RELEASE_DATE" >> "$GITHUB_ENV"
-          echo "Release date: $RELEASE_DATE (from $DATE_SOURCE)"
-
-
-      - name: "Docs: check out this repository for the generator scripts"
-        if: ${{ env.PERIOD == 'quarterly' }}
-        uses: actions/checkout@v5
-        with:
-          path: self
-          persist-credentials: false
 
       - name: "Docs: check out armbian/build for board and family names"
         if: ${{ env.PERIOD == 'quarterly' }}

--- a/scripts/resolve-release-window.py
+++ b/scripts/resolve-release-window.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Resolve the date and the PR window for one quarterly release note.
+
+Both have to be reproducible. Regenerating a quarter months later must
+produce the same page, so neither the date nor the window may be read from
+the clock once the quarter has been published.
+
+The window is anchored to the releases either side of it rather than to a
+rolling three months. A clock-based window slides: rebuilding 26.8 three
+weeks late would drop three weeks of PRs off the start -- PRs that belong to
+26.8 and appear in no other note -- and pull in three weeks of post-release
+work that belongs to the next quarter. Same length, wrong contents.
+
+The previous quarter's date comes from its own published page, which is the
+project's record of where quarters begin and end and owes nothing to tag or
+release retention in other repositories.
+"""
+
+import argparse
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+
+RE_RELEASED = re.compile(r"^\*Released ([^*]+)\*\s*$", re.MULTILINE)
+RE_VERSION_FILE = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?\.md$")
+
+HUMAN = "%-d %B %Y"
+
+
+def human(dt):
+    # %-d is glibc; the workflow runs on ubuntu. Avoids a leading zero.
+    return dt.strftime(HUMAN)
+
+
+def parse_human(text):
+    """Parse the '29 May 2026' form the pages carry. Returns None if it isn't."""
+    try:
+        return datetime.strptime(text.strip(), "%d %B %Y").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def sort_key(match):
+    return tuple(int(p) for p in match.groups(default="0"))
+
+
+def released_on(path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            match = RE_RELEASED.search(fh.read())
+    except OSError:
+        return None
+    return parse_human(match.group(1)) if match else None
+
+
+def scan(releases_dir):
+    """Every release page that carries a date, newest first."""
+    found = []
+    try:
+        names = os.listdir(releases_dir)
+    except OSError:
+        return found
+    for name in sorted(names):
+        match = RE_VERSION_FILE.match(name)
+        if not match:
+            continue
+        date = released_on(os.path.join(releases_dir, name))
+        if date:
+            found.append((sort_key(match), name[: -len(".md")], date))
+    found.sort(reverse=True)
+    return found
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--releases-dir", required=True)
+    ap.add_argument("--docs-version", required=True,
+                    help="the quarter being written, e.g. 26.8")
+    ap.add_argument("--release-date", default="",
+                    help="explicit override, e.g. '29 May 2026'")
+    ap.add_argument("--published-at", default="",
+                    help="published_at of the armbian/build release, if one exists")
+    ap.add_argument("--today", default="",
+                    help="ISO date to treat as today; defaults to the real clock")
+    ap.add_argument("--fallback-months", type=int, default=3)
+    args = ap.parse_args()
+
+    today = (datetime.fromisoformat(args.today.replace("Z", "+00:00"))
+             if args.today else datetime.now(timezone.utc))
+
+    pages = scan(args.releases_dir)
+    this_key = sort_key(RE_VERSION_FILE.match(args.docs_version + ".md"))
+
+    # --- the release date -------------------------------------------------
+    # Ordered by how durable each source is, not by convenience.
+    date, source = None, None
+    if args.release_date:
+        date = parse_human(args.release_date)
+        if not date:
+            print("::error::--release-date {!r} is not of the form "
+                  "'29 May 2026'".format(args.release_date), file=sys.stderr)
+            return 1
+        source = "the release_date input"
+    if not date:
+        # Already published: its date is a matter of record and must not move.
+        for key, _version, when in pages:
+            if key == this_key:
+                date, source = when, "the published page, which is the record"
+                break
+    if not date and args.published_at:
+        stamp = args.published_at.replace("Z", "+00:00")
+        try:
+            date = datetime.fromisoformat(stamp)
+            source = "the armbian/build release"
+        except ValueError:
+            date = None
+    if not date:
+        # A fresh quarter, published the day this runs. Pinned by the page
+        # from the next run onwards.
+        date, source = today, "today, the day this ran"
+
+    # --- the window -------------------------------------------------------
+    previous = next((p for p in pages if p[0] < this_key), None)
+    if previous:
+        since = previous[2]
+        window_source = "the {} page, released {}".format(previous[1], human(since))
+    else:
+        since = date - timedelta(days=args.fallback_months * 31)
+        window_source = ("no earlier release page; falling back to {} months "
+                         "before the release".format(args.fallback_months))
+        print("::warning title=Release window::No release page older than {}; "
+              "the window start is approximate".format(args.docs_version),
+              file=sys.stderr)
+
+    # Midnight of the previous release day through the end of this one. The
+    # overlap that costs -- a few PRs merged earlier on the previous release
+    # day get listed twice -- is deliberate: a duplicate is visible in the
+    # page, a dropped PR is not.
+    since = since.replace(hour=0, minute=0, second=0, microsecond=0)
+    until = date.replace(hour=23, minute=59, second=59, microsecond=0)
+
+    if since >= until:
+        print("::error::window start {} is not before its end {}".format(
+            since.isoformat(), until.isoformat()), file=sys.stderr)
+        return 1
+
+    out = [
+        ("RELEASE_DATE", human(date)),
+        ("RELEASE_DATE_SOURCE", source),
+        ("SINCE_UTC", since.strftime("%Y-%m-%dT%H:%M:%SZ")),
+        ("UNTIL_UTC", until.strftime("%Y-%m-%dT%H:%M:%SZ")),
+        ("WINDOW_SOURCE", window_source),
+    ]
+    for key, value in out:
+        print("{}={}".format(key, value))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #420 — based on `docs/publish-quarterly-release-notes`, so GitHub will retarget this to `main` once that merges.

Two changes to the quarterly path, plus a bug each turned up.

## 1. Only the weekly digest becomes a GitHub release

Quarterly and monthly stop publishing to `armbian/build`. Weekly is unchanged.

The quarterly note now lives on docs.armbian.com, and that is the only copy search engines can see — GitHub serves release pages `noindex`. Publishing both left two copies of the same writing competing, and the invisible one was winning by default.

It also had side effects nobody asked for. No `v26.8.3` tag exists in `armbian/build` — stable tags live in `armbian/ci` — so `ncipollo` created one against `main`, and `makeLatest: true` moved the "Latest" badge onto it.

**Monthly stops too.** It selects the same stable tag as quarterly, so whichever ran first won the tag and `skipIfReleaseExists` made the other a silent no-op: a quarterly run could quietly leave a monthly body in place.

Nothing downstream depends on this. I grepped `build`, `armbian.github.io`, `configng` and `actions` — every `releases/latest` call targets a third-party repo (radxa-pkg, SyterKit, edk2-rk3588, configng). The only consumers of the stable series are humans. "Latest" is already pinned to `v26.11.0-trunk.11`, a weekly, so the badge is not marking a stable release today either.

## 2. The quarterly window is anchored to the releases, not the clock

`SINCE = now − 3 months` made the page a function of when the button was pressed. Regenerating 26.8 three weeks late would **drop three weeks of PRs off the start** — PRs that belong to 26.8 and would then appear in no release note at all — while pulling in three weeks of work belonging to 26.11. Same length, different contents.

The window now runs from the previous quarter's release date to this one's, both read from the pages themselves. Regenerating a quarter reproduces it exactly.

Adjacent quarters overlap by **exactly one day**, the previous release day, since pages carry day granularity and the start is taken at midnight. Deliberate: a PR listed twice is visible in the page, a PR dropped between two windows is not.

## 3. The date needed a source that does not move

With no release to read, `published_at` 404s and the old code fell back to *today*, changing on every re-run. Resolution order is now: explicit `release_date` input → the published page → the `armbian/build` release → today.

**The `armbian/ci` tag is deliberately not a source.** It is when the build was cut, not when the release was published — `26.8.3` is tagged 18 August for a release going out on the 24th. A fresh quarter is dated the day it is published, which is how this has always been run, and pinned by its own page from then on.

On retention: `armbian/ci` runs `delete-old-releases.yml` daily, keeping 3 stable and 3 trunk, but it deletes **releases only** — tags are untouched (`26.8.0` and `26.5.2` are tags there today with no release). Reading the date off the page makes the question moot regardless.

## Structure

Resolving the window needs the version and date *before* the window is computed, so the version step, both checkouts and the date resolution move above it. The version step reads only `PERIOD` and a public `git ls-remote`, so it moves freely. The logic itself moved into `scripts/resolve-release-window.py` where it can be tested.

## Verification

Step bodies extracted from the YAML and run for real.

Gating, all six combinations:

| period | publish_release | release |
|---|---|---|
| weekly | true | **true** |
| weekly | false | false |
| monthly | true / false | false |
| quarterly | true / false | false |

Window and date:

| Case | Result |
|---|---|
| Fresh 26.8, published 24 Aug | `2026-05-29T00:00:00Z` → `2026-08-24T23:59:59Z` |
| **Same quarter regenerated 3 weeks later, no input** | **identical date and window** |
| Next quarter 26.11 | starts `2026-08-24T00:00:00Z` — exactly one day of overlap |
| First-ever quarter, no prior page | warns, approximates from the release date |
| Historical 26.5 | date from the page, window `2026-02-28` → `2026-05-29` |
| Malformed `release_date` | `::error::`, exit 1 |

Output is locale-independent (verified under `sl_SI.UTF-8`), keeps single-digit days unpadded, and round-trips through its own parser. Every `run:` step passes `bash -n`; the workflow parses as YAML.