### PR TITLE
release-summary: push the docs PR as armbianworker

### DIFF
--- a/.github/workflows/reporting-release-summary.yml
+++ b/.github/workflows/reporting-release-summary.yml
@@ -105,13 +105,21 @@ jobs:
           path: self
           persist-credentials: false
 
+      # Checked out ahead of the resolver below, which reads the previous
+      # quarter's page to date this one and to anchor its window.
+      #
+      # ACCESS_TOKEN_ARMBIANWORKER, not RELEASE_TOKEN: the latter can write
+      # releases to armbian/build but has no write access to
+      # armbian/documentation, so the push at the end of this job 403s after
+      # every expensive step has already run. armbianworker has write on
+      # armbian/documentation and already opens PRs this way elsewhere.
       - name: "Docs: check out armbian/documentation"
         if: ${{ env.PERIOD == 'quarterly' }}
         uses: actions/checkout@v5
         with:
           repository: armbian/documentation
           path: documentation
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN_ARMBIANWORKER }}
           persist-credentials: false
 
       - name: "Docs: resolve the release date and the docs version"
@@ -796,7 +804,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           path: documentation
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN_ARMBIANWORKER }}
           # One branch per quarter, so a re-run -- including for a later patch
           # release in the same quarter -- updates the open PR in place rather
           # than opening a second one.


### PR DESCRIPTION
Fixes the 403 that killed the first quarterly run: [run 32661180678](https://github.com/armbian/armbian.github.io/actions/runs/32661180678/job/97247499515).

```
remote: Permission to armbian/documentation.git denied to igorpecovnik.
fatal: ... The requested URL returned error: 403
```

`RELEASE_TOKEN` can write releases to `armbian/build`, but has no write access to `armbian/documentation`. The checkout succeeded only because that repo is public — reads need no auth — so the job generated the page, regenerated the index, and then died on the final push, after both the Anthropic and Gemini calls had already been paid for.

### Why armbianworker

Its access is what's missing, checked directly:

```
armbianworker on armbian/documentation     -> write
armbianworker on armbian/armbian.github.io -> write
armbianworker on armbian/build             -> write
armbianworker on armbian/ci                -> write
org member: yes
```

And the token is already used for exactly this pattern in `armbian/ci`:

```yaml
- name: Open a PR if the options changed
  uses: peter-evans/create-pull-request@v8
  with:
    token: ${{ secrets.ACCESS_TOKEN_ARMBIANWORKER }}
```

It appears in six repos across the org — `os`, `ci`, `configng`, `autotests`, `scripts` — so this is the established way automation opens cross-repo PRs here.

### The change

Both `armbian/documentation` steps switch token. The `armbian/build` release keeps `RELEASE_TOKEN`, which already works there.

| Step | Token |
|---|---|
| Docs: check out armbian/documentation | `ACCESS_TOKEN_ARMBIANWORKER` |
| ncipollo/release-action@v1 | `RELEASE_TOKEN` (unchanged) |
| Docs: open or update the pull request | `ACCESS_TOKEN_ARMBIANWORKER` |

### Everything else in that run worked

Worth recording, since it was the first real run of the new logic:

```
Selected quarterly version from armbian/ci tags: 26.8.3
Docs version: 26.8 (from 26.8.3)
RELEASE_DATE=23 August 2026
SINCE_UTC=2026-05-29T00:00:00Z          <- anchored to the 26.5 page
UNTIL_UTC=2026-08-23T23:59:59Z
WINDOW_SOURCE=the 26.5 page, released 29 May 2026
Period quarterly: GitHub release enabled = false
wrote documentation/docs/releases/index.md with 7 release(s), 4 featured
```

The window anchoring resolved 29 May from the 26.5 page, no `v26.8.3` release was created on `armbian/build`, and the index regenerated. The push failing left nothing behind to clean up.

### Before re-running

- **Confirm the org secret reaches this repo.** Listing org secrets needs `admin:org`, so I could not verify it. If `ACCESS_TOKEN_ARMBIANWORKER` has "selected repositories" visibility, `armbian.github.io` may not be on the list — none of the six current users is this repo. An empty token fails the same way.
- **Pass `release_date`** if the note should not be dated the day the workflow runs. Nothing pins it until the page is merged.

YAML parses, all `run:` steps pass `bash -n`.