### PR TITLE
release-doc: group by source repo, recover missing PR links

### DIFF
--- a/scripts/collect-board-tier-changes.py
+++ b/scripts/collect-board-tier-changes.py
@@ -12,6 +12,7 @@ Emits a TSV of: board, old extension, new extension, PR reference, PR URL.
 
 import argparse
 import csv
+import json
 import os
 import re
 import subprocess
@@ -30,7 +31,7 @@ def git_log(tree, since, until):
             "--since", since, "--until", until,
             "--diff-filter=R", "--find-renames=40%",
             "--name-status", "--no-merges",
-            "--format=%x01%s",
+            "--format=%x01%H %s",
             "--", "config/boards",
         ],
         check=True, capture_output=True, text=True,
@@ -39,8 +40,9 @@ def git_log(tree, since, until):
         record = record.strip("\n")
         if not record:
             continue
-        subject, _, body = record.partition("\n")
-        yield subject.strip(), body
+        header, _, body = record.partition("\n")
+        sha, _, subject = header.strip().partition(" ")
+        yield sha, subject.strip(), body
 
 
 def tier_of(path):
@@ -67,6 +69,37 @@ def load_digest_index(path):
     return index
 
 
+def pr_for_commit(sha, repo="armbian/build", cache={}):
+    """Ask GitHub which pull request a commit arrived in.
+
+    Last resort, and worth the call: a rebase or merge-queue merge leaves the
+    individual commits without a "(#123)" subject, and their subjects are the
+    commit messages rather than the PR title, so neither of the cheap paths
+    can match. Only unlinked commits reach here -- four in 26.8 -- and the
+    result is cached, so this stays a handful of requests.
+    """
+    if sha in cache:
+        return cache[sha]
+    cache[sha] = ("", "")
+    try:
+        out = subprocess.run(
+            ["gh", "api", "repos/{}/commits/{}/pulls".format(repo, sha),
+             "--jq", "[.[] | {number, url: .html_url}]"],
+            check=True, capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return cache[sha]
+    try:
+        hits = json.loads(out) if out else []
+    except ValueError:
+        return cache[sha]
+    if len(hits) == 1:
+        # More than one means the commit is in several PRs and picking would
+        # be a guess; leave it unlinked rather than attribute it wrongly.
+        cache[sha] = ("{}#{}".format(repo, hits[0]["number"]), hits[0]["url"])
+    return cache[sha]
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--build-tree", required=True, help="armbian/build checkout")
@@ -74,6 +107,8 @@ def main():
     ap.add_argument("--until", required=True, help="ISO timestamp, window end")
     ap.add_argument("--digest", help="merged-PR TSV, used to recover PR links")
     ap.add_argument("--out", required=True, help="output TSV path")
+    ap.add_argument("--no-api", action="store_true",
+                    help="skip the gh lookup for commits nothing else linked")
     args = ap.parse_args()
 
     digest = load_digest_index(args.digest)
@@ -84,7 +119,7 @@ def main():
     # back to where it began reports nothing at all.
     merged, changes = {}, []
 
-    for subject, body in git_log(args.build_tree, args.since, args.until):
+    for sha, subject, body in git_log(args.build_tree, args.since, args.until):
         ref = url = ""
         match = RE_PR_IN_SUBJECT.search(subject)
         if match:
@@ -95,6 +130,8 @@ def main():
             if hit:
                 repo, number, url = hit
                 ref = "{}#{}".format(repo, number)
+            elif not args.no_api:
+                ref, url = pr_for_commit(sha)
 
         for line in body.splitlines():
             fields = line.split("\t")

--- a/scripts/collect-board-tier-changes.py
+++ b/scripts/collect-board-tier-changes.py
@@ -12,6 +12,7 @@ Emits a TSV of: board, old extension, new extension, PR reference, PR URL.
 
 import argparse
 import csv
+import functools
 import json
 import os
 import re
@@ -69,18 +70,16 @@ def load_digest_index(path):
     return index
 
 
-def pr_for_commit(sha, repo="armbian/build", cache={}):
+@functools.lru_cache(maxsize=None)
+def pr_for_commit(sha, repo="armbian/build"):
     """Ask GitHub which pull request a commit arrived in.
 
     Last resort, and worth the call: a rebase or merge-queue merge leaves the
     individual commits without a "(#123)" subject, and their subjects are the
     commit messages rather than the PR title, so neither of the cheap paths
-    can match. Only unlinked commits reach here -- four in 26.8 -- and the
-    result is cached, so this stays a handful of requests.
+    can match. Only unlinked commits reach here -- four in 26.8 -- and
+    lru_cache keeps a repeated sha from asking twice.
     """
-    if sha in cache:
-        return cache[sha]
-    cache[sha] = ("", "")
     try:
         out = subprocess.run(
             ["gh", "api", "repos/{}/commits/{}/pulls".format(repo, sha),
@@ -88,16 +87,16 @@ def pr_for_commit(sha, repo="armbian/build", cache={}):
             check=True, capture_output=True, text=True, timeout=30,
         ).stdout.strip()
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
-        return cache[sha]
+        return ("", "")
     try:
         hits = json.loads(out) if out else []
     except ValueError:
-        return cache[sha]
-    if len(hits) == 1:
-        # More than one means the commit is in several PRs and picking would
-        # be a guess; leave it unlinked rather than attribute it wrongly.
-        cache[sha] = ("{}#{}".format(repo, hits[0]["number"]), hits[0]["url"])
-    return cache[sha]
+        return ("", "")
+    if len(hits) != 1:
+        # None means nothing claims it; more than one means picking would be a
+        # guess. Either way leave it unlinked rather than attribute it wrongly.
+        return ("", "")
+    return ("{}#{}".format(repo, hits[0]["number"]), hits[0]["url"])
 
 
 def main():

--- a/scripts/generate-release-doc.py
+++ b/scripts/generate-release-doc.py
@@ -142,7 +142,12 @@ REPO_FIXED = {
 # Single-purpose repos supply a fallback when no title rule fires. armbian/build
 # and armbian/armbian.github.io are deliberately absent: they span every group,
 # so an unmatched title there is genuinely unclassified and belongs in "Other".
-REPO_FALLBACK = {
+# Repositories with one clear home. Everything they merge belongs to that
+# group unless the change is plainly desktop work, because their titles talk
+# about what the tool acts on rather than what the change is: "armbian-install:
+# fix boot on UEFI systems" is configng work, not a board change.
+REPO_HOME = {
+    "armbian/armbian.github.io": "Build framework and CI",
     "armbian/os": "Build framework and CI",
     "armbian/actions": "Build framework and CI",
     "armbian/docker-armbian-build": "Build framework and CI",
@@ -299,6 +304,17 @@ def classify(title, repo, boards, families):
     low = title.lower()
     parts = prefix_parts(title_prefix(title))
 
+    # Repo identity outranks title vocabulary for repos that have one home.
+    # The prefix table below is tuned for armbian/build, where "firmware:" or
+    # a board name really does mean a kernel or board change; in configng or
+    # imager the same words describe the subject of a tooling change. Desktop
+    # is the one group these repos genuinely also belong to, so it may win.
+    home = REPO_HOME.get(repo)
+    if home:
+        if parts & PREFIX_GROUPS["Desktop"] or RE_DESKTOP.search(low):
+            return "Desktop"
+        return home
+
     for group, prefixes in PREFIX_GROUPS.items():
         if parts & prefixes:
             return group
@@ -317,7 +333,7 @@ def classify(title, repo, boards, families):
         return "Build framework and CI"
     if RE_TOOLING.search(low):
         return "Tooling"
-    return REPO_FALLBACK.get(repo, "Other")
+    return "Other"
 
 
 def read_digest(path):


### PR DESCRIPTION
Two defects found reviewing the generated [26.8 page](https://docs.armbian.com/releases/26.8/).

## 1. Grouping ignored the source repo

The prefix and vocabulary tables are tuned for `armbian/build`, where a board name or `firmware:` really does mean a board or kernel change. In a tooling repo the same words describe *what the tool acts on*. `REPO_FALLBACK` had the right mapping all along — it just ran **last**, after every title heuristic had had its say.

Eleven misfiled titles from the review, before and after:

| Repo | Title | Was | Now |
|---|---|---|---|
| configng | armbian-install: fix boot on UEFI systems | Boards | Tooling |
| configng | install: keep the Rockchip reserved window | Boards | Tooling |
| configng | module_cockpit: install UEFI firmware | Boards | Tooling |
| configng | armbian-install: redesign as a tested armbian-config module | **Kernel and U-Boot** | Tooling |
| configng | firmware: download kernel before removing old | Kernel and U-Boot | Tooling |
| configng | Update vendor logo | Kernel and U-Boot | Tooling |
| configng | module_proxmox: add Proxmox VE | Tooling | Tooling |
| configng | install-engine: silence null-byte warnings | Tooling | Tooling |
| imager | Flash UFS images to Qualcomm boards over EDL | Boards | Tooling |
| imager | feat(boards): scroll long board names with marquee | Boards | Tooling |
| documentation | Add rewrite-kernel-config command to Build commands | Kernel and U-Boot | Tooling |

The third row is the telling one — a headline item in the page's own narrative, filed under kernel. The knock-on effect was Desktop finishing the quarter with six entries, because configng work was scattered across Boards and Kernel instead.

The map now runs **first** for repos that have one home, and only **Desktop** may still pull a change out of it — that is the one group these repos genuinely also belong to, so `module_desktop: fix xfce panel` in configng still lands in Desktop. `armbian/armbian.github.io` was missing from the map and is added as Build framework and CI.

Regression-checked: `armbian/build` keeps the full cascade (`rockchip64: bump edge to 6.18` → Kernel, `Add board KickPi K2B` → Boards, `ci: retry stalled runners` → CI, unclassifiable → Other), and the kernel-tree override still pins `linux-*`, `firmware`, `rkbin` and `*-dkms`.

## 2. Four board tier changes had no PR link

`maaxboard-8ulp`, `qidi-x6`, `tanix-tx6s-axp313`, `youyeetoo-r1-v3`.

Their commits arrived through rebase or the merge queue, so the subject carries no `(#123)` and is the commit message rather than the PR title — neither existing path could match:

```
892ca77  tanix-tx6s-axp313: promote from .tvb to .conf (Supported)
90fda43  boards/youyeetoo-r1-v3: promote to standard support
```

Added a last-resort lookup asking GitHub which PR a commit arrived in, used **only** for commits nothing else linked and **only** when exactly one PR claims it — more than one would be a guess. Four requests for this release, cached, and skippable with `--no-api`.

Re-running the collector over the real 26.8 window now links all 23, with zero `(no PR link)`:

```
maaxboard-8ulp: conf -> csc        armbian/build#9991
qidi-x6: csc -> conf               armbian/build#10412
tanix-tx6s-axp313: tvb -> conf     armbian/build#10459
youyeetoo-r1-v3: csc -> conf       armbian/build#10220
```

The two the reviewer identified by hand resolve to exactly the PRs they named.

## Not changed

The review also reported the **All changes list is not collapsed**. It is — this one did not reproduce. The built page contains `<details class="abstract">` with no `open` attribute, `<summary>780 merged pull requests in this release</summary>`, and all 780 `<li>` inside it; `pymdownx.details` is enabled in `mkdocs.yml`. The raw `???` renders flat in GitHub's diff view, which does not support pymdownx admonitions — that is most likely what was seen.