### PR TITLE
release-doc: reach the kernel and CI repos the repo table still missed

### DIFF
--- a/scripts/collect-board-tier-changes.py
+++ b/scripts/collect-board-tier-changes.py
@@ -148,6 +148,12 @@ def main():
                 continue
             if old_stem in merged:
                 merged[old_stem][0] = old_ext
+                # The newest hop owns the link, since it produced the tier the
+                # board ends the window on. But if nothing could link that hop,
+                # an older one is a better answer than no link at all.
+                if not merged[old_stem][2] and ref:
+                    merged[old_stem][2] = ref
+                    merged[old_stem][3] = url
             else:
                 merged[old_stem] = [old_ext, new_ext, ref, url]
 

--- a/scripts/generate-release-doc.py
+++ b/scripts/generate-release-doc.py
@@ -131,12 +131,22 @@ RE_PREFIX_CI_PART = re.compile(
     r"generate|generation|release|repo|docker|deps|dispatch|sync)(-|$)"
 )
 
-# Repos whose entire output belongs to one group regardless of title.
+# Repos whose entire output belongs to one group regardless of title. Kernel
+# mirrors, firmware-blob collections and out-of-tree drivers whose names the
+# pattern below does not reach: 'uwe5622' names the chip, 'mtkbin' and
+# 'odroidc2-blobs' name the vendor, and 'phytium-linux-kernel' puts the vendor
+# ahead of 'linux'.
 REPO_FIXED = {
+    "armbian/linux": "Kernel and U-Boot",
     "armbian/linux-rockchip": "Kernel and U-Boot",
+    "armbian/phytium-linux-kernel": "Kernel and U-Boot",
     "armbian/rkbin": "Kernel and U-Boot",
-    "armbian/firmware": "Kernel and U-Boot",
+    "armbian/mtkbin": "Kernel and U-Boot",
     "armbian/qcombin": "Kernel and U-Boot",
+    "armbian/odroidc2-blobs": "Kernel and U-Boot",
+    "armbian/firmware": "Kernel and U-Boot",
+    "armbian/sunxi-dt-overlays": "Kernel and U-Boot",
+    "armbian/uwe5622": "Kernel and U-Boot",
 }
 
 # Single-purpose repos supply a fallback when no title rule fires. armbian/build
@@ -153,11 +163,14 @@ REPO_HOME = {
     "armbian/docker-armbian-build": "Build framework and CI",
     "armbian/sdk": "Build framework and CI",
     "armbian/ci": "Build framework and CI",
+    "armbian/distribution": "Build framework and CI",
+    "armbian/shallow": "Build framework and CI",
     "armbian/configng": "Tooling",
     "armbian/imager": "Tooling",
     "armbian/documentation": "Tooling",
     "armbian/website": "Tooling",
     "armbian/armbian-router": "Tooling",
+    "armbian/scripts": "Tooling",
 }
 
 
@@ -281,10 +294,16 @@ def names_a_board(title, boards, families):
 
 
 def repo_fixed_group(repo):
-    """Kernel-tree, firmware-blob and out-of-tree driver repos, by pattern."""
-    if repo in REPO_FIXED:
-        return REPO_FIXED[repo]
-    name = repo.split("/", 1)[-1].lower()
+    """Kernel-tree, firmware-blob and out-of-tree driver repos, by pattern.
+
+    Matched case-insensitively: the org spells repos both ways
+    (MorseMicro-DKMS, sunxi-DT-overlays), and the digest reports whatever
+    GitHub reports.
+    """
+    lowered = repo.lower()
+    if lowered in REPO_FIXED:
+        return REPO_FIXED[lowered]
+    name = lowered.split("/", 1)[-1]
     if name.startswith(("linux-", "wifi-", "rtl", "rtw")) or name.endswith("-dkms"):
         return "Kernel and U-Boot"
     return None

--- a/scripts/generate-release-doc.py
+++ b/scripts/generate-release-doc.py
@@ -328,7 +328,7 @@ def classify(title, repo, boards, families):
     # a board name really does mean a kernel or board change; in configng or
     # imager the same words describe the subject of a tooling change. Desktop
     # is the one group these repos genuinely also belong to, so it may win.
-    home = REPO_HOME.get(repo)
+    home = REPO_HOME.get(repo.lower())  # keys are lowercase; GitHub reports repos in mixed case
     if home:
         if parts & PREFIX_GROUPS["Desktop"] or RE_DESKTOP.search(low):
             return "Desktop"


### PR DESCRIPTION
Follow-up on the three defects reported against `/releases/26.8/`. Two of the three are already fixed on `main`; this PR closes the gap left in the third, plus a related bug in the board-tier collector.

## Status of the three reported defects

| # | Defect | Status |
|---|---|---|
| 1 | "All changes" renders flat, 780 entries inline | :white_check_mark: **Already fixed on `main`** — `generate-release-doc.py` wraps the list in `??? abstract "{n} merged pull requests in this release"`. No change needed. |
| 2 | Grouping keys off title keywords instead of source repository | :warning: **Partly fixed on `main`** (`49a745e`), but the repo tables miss several repos. **This PR.** |
| 3 | Four board status entries have no PR link | :white_check_mark: **Already fixed on `main`** (`49a745e`) — `collect-board-tier-changes.py` now falls back to `gh api repos/…/commits/{sha}/pulls`. The committed `26.8.md` has all four links (`#9991`, `#10412`, `#10459`, `#10220`). A **latent** case remained; see below. |

### Verifying #2 against the reported examples

Every misfiled PR named in the report already classifies correctly on `main`:

```
ok  armbian/configng   armbian-install: fix boot on UEFI systems            -> Tooling
ok  armbian/configng   install-engine: silence null-byte warnings           -> Tooling
ok  armbian/configng   install: keep the Rockchip reserved window           -> Tooling
ok  armbian/configng   module_cockpit: install UEFI firmware                -> Tooling
ok  armbian/imager     Flash UFS images to Qualcomm boards over EDL         -> Tooling
ok  armbian/imager     feat(boards): scroll long board names with marquee   -> Tooling
ok  armbian/configng   armbian-install: redesign as a tested … module       -> Tooling
ok  armbian/configng   module_proxmox: add Proxmox VE                       -> Tooling
ok  armbian/configng   firmware: download kernel before removing old        -> Tooling
ok  armbian/documentation  Add rewrite-kernel-config command …              -> Tooling
ok  armbian/armbian.github.io  Update vendor logo                           -> Build framework and CI
```

## What this PR fixes

Five repos in the brief's rule set have no entry in either table, so their changes are still classified by title alone:

| Repo | Was | Now | Why the pattern missed it |
|---|---|---|---|
| `armbian/uwe5622` | 14 in *Other*, 1 *CI*, 1 *Tooling* | Kernel and U-Boot | Out-of-tree wifi driver, but the name is the **chip** — no `wifi-` prefix, no `-dkms` suffix |
| `armbian/phytium-linux-kernel` | *Build framework and CI* | Kernel and U-Boot | Vendor comes before `linux`, so `startswith("linux-")` misses it |
| `armbian/linux` | — | Kernel and U-Boot | Exactly `linux`; the rule needs `linux-` |
| `armbian/distribution` | *Tooling* / *CI* (split) | Build framework and CI | No entry |
| `armbian/shallow` | *CI* by luck of the title | Build framework and CI | No entry |

Also added while in the table, matching the brief's "firmware blob" class alongside `rkbin` and `qcombin`: `armbian/mtkbin`, `armbian/odroidc2-blobs`, `armbian/sunxi-DT-overlays`.

Repo lookups are now **case-insensitive** — the org spells repos both ways (`MorseMicro-DKMS`, `sunxi-DT-overlays`), and the digest carries whatever GitHub reports.

### Beyond the brief's list

One addition not in the brief, called out for review: **`armbian/scripts` → Tooling**. The repo is literally "Armbian Linux Support Scripts" and its one 26.8 entry sat in *Other*. Say the word and I'll drop it.

## Effect on the real 26.8 dataset

Replaying all 782 entries from the published `26.8.md` through the classifier:

| Group | Before | After |
|---|---|---|
| Boards | 124 | **124** |
| Kernel and U-Boot | 267 | 283 |
| Desktop | 8 | **8** |
| Build framework and CI | 221 | 220 |
| Tooling | 91 | 90 |
| **Other** | **71** | **57** |

18 entries move, all into a better home. Boards and Desktop are untouched, so nothing that was already right gets disturbed.

`configng` / `imager` PRs under *Boards* or *Kernel and U-Boot*: **0**.

## Latent bug in `collect-board-tier-changes.py`

Separate from #3's `gh api` fallback. A board that moves **twice** in one window (`wip → csc → conf`) correctly reports the widened range, but keeps only the **newest** hop's PR link. If that newest hop is a merge-queue commit nothing can resolve — no `(#123)` subject, absent from the digest, and `gh api` returns zero or several PRs — the entry renders unlinked even though the older hop carries a perfectly good `(#123)`.

Fixed by backfilling: the newest hop still owns the link, since it produced the tier the board ends the window on; an older hop's link is used only when the newer one has none.

Reproduced with a two-hop fixture where the newest commit is unlinkable:

```
before:  demoboard: wip -> conf (no PR link)
after:   demoboard: wip -> conf armbian/build#123
```

## Verification

- Both scripts compile.
- 31-case classifier table covering every repo in the brief's rule set, the reported misfiles, `configng` desktop modules (which must still beat the repo home and reach *Desktop*), and `armbian/build` falling through to the title heuristics: **31/31 pass** (25/31 before this PR).
- Full 782-entry 26.8 replay as above.
- The weekly digest workflow is untouched.