### PR TITLE
harden the PR labeling workflows

### DIFF
--- a/.github/workflows/label-auto-on-pr.yml
+++ b/.github/workflows/label-auto-on-pr.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - name: Checkout the pull request
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # only here so `gh` can resolve the repo from the git remote; no
+          # authenticated git commands run, so don't leave the token behind
+          persist-credentials: false
 
       - name: Check for label using GH CLI
         id: check
@@ -49,6 +53,8 @@ jobs:
     steps:
       # Checks out the repository to read files for matching with labeler config
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Applies labels based on the .github/labeler.yml config
       - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0

--- a/.github/workflows/label-auto-on-pr.yml
+++ b/.github/workflows/label-auto-on-pr.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout the pull request
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check for label using GH CLI
         id: check
@@ -35,7 +35,7 @@ jobs:
 
       - name: Remove "Ready to merge" label
         if: steps.check.outputs.has_label == 'true'
-        uses: PauMAVA/add-remove-label-action@v1.0.3
+        uses: PauMAVA/add-remove-label-action@d1dae9b1a6c5b44b7740a3e7f64723fe7c9619d3 # v1.0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add: ""
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       # Checks out the repository to read files for matching with labeler config
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Applies labels based on the .github/labeler.yml config
-      - uses: actions/labeler@v7
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -63,7 +63,7 @@ jobs:
     steps:
       # Automatically adds size labels based on total changed lines
       - name: Label by size
-        uses: pascalgn/size-label-action@v0.5.7
+        uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff # v0.5.7
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
@@ -107,7 +107,7 @@ jobs:
 
       # Adds the quarter label to the PR
       - name: Add quarter label
-        uses: PauMAVA/add-remove-label-action@v1.0.3
+        uses: PauMAVA/add-remove-label-action@d1dae9b1a6c5b44b7740a3e7f64723fe7c9619d3 # v1.0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add: "${{ env.LABEL }}"

--- a/.github/workflows/label-listen-pr-review.yml
+++ b/.github/workflows/label-listen-pr-review.yml
@@ -3,6 +3,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
   ping:
     if: ${{ github.event.review.state == 'approved' }}
@@ -13,7 +16,7 @@ jobs:
       - name: Save PR number
         run: echo "${{ github.event.pull_request.number }}" > pr.txt
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # unique name: includes workflow run id
           name: pr-number-${{ github.run_id }}

--- a/.github/workflows/label-pr-on-approval.yml
+++ b/.github/workflows/label-pr-on-approval.yml
@@ -53,11 +53,16 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const issue_number = Number.parseInt(process.env.PR_NUMBER || "", 10);
-            if (!Number.isInteger(issue_number) || issue_number <= 0) {
-              core.setFailed("Invalid PR number in PR_NUMBER");
+            // Strict on purpose: Number.parseInt takes the longest valid prefix,
+            // so "123abc" and "1e3" would coerce to 123 and 1 and sail past an
+            // isInteger check -- stripping labels off whatever PR that happens to
+            // be. Demand canonical digits and fail loudly otherwise.
+            const raw = (process.env.PR_NUMBER || "").trim();
+            if (!/^[1-9][0-9]*$/.test(raw)) {
+              core.setFailed(`Invalid PR number in PR_NUMBER: ${JSON.stringify(raw)}`);
               return;
             }
+            const issue_number = Number(raw);
             const labelsToRemove = ["Needs review", "Work in progress", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
 
             for (const name of labelsToRemove) {

--- a/.github/workflows/label-pr-on-approval.yml
+++ b/.github/workflows/label-pr-on-approval.yml
@@ -30,6 +30,7 @@ jobs:
         run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
 
       - name: Label when approved
+        id: approval
         uses: j-fulbright/label-when-approved-action@911c622c75f8ea99ee00cdd66e2cd888bac530c6 # v1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,7 +41,12 @@ jobs:
           pullRequestNumber: ${{ steps.pr.outputs.number }}
 
       - name: Remove review-related labels
-        if: ${{ success() }}
+        # Not just success(): the action exits 0 and reports isApproved=false when
+        # the approval does not come from a committer (require_committers_approval),
+        # and anyone with read access can approve a PR on a public repo. Without
+        # this gate a drive-by approval clears the review-tracking labels below
+        # while "Ready to merge" is (correctly) never added.
+        if: ${{ success() && steps.approval.outputs.isApproved == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/label-pr-on-approval.yml
+++ b/.github/workflows/label-pr-on-approval.yml
@@ -26,8 +26,18 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}           # ← CRITICAL: fetch from the upstream run
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Validate here, at the point the value enters the job: everything below
+      # consumes it, starting with an action that parseInt()s it and then reads
+      # and writes labels. A check further down would run after those writes --
+      # and on the not-approved path would not run at all.
       - id: pr
-        run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
+        run: |
+          number="$(tr -d '[:space:]' < pr.txt)"
+          case "${number}" in
+            '' | *[!0-9]*) echo "::error::pr.txt is not a PR number: '${number}'"; exit 1 ;;
+            0*)            echo "::error::pr.txt is not a canonical PR number: '${number}'"; exit 1 ;;
+          esac
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
 
       - name: Label when approved
         id: approval
@@ -53,10 +63,10 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            // Strict on purpose: Number.parseInt takes the longest valid prefix,
-            // so "123abc" and "1e3" would coerce to 123 and 1 and sail past an
-            // isInteger check -- stripping labels off whatever PR that happens to
-            // be. Demand canonical digits and fail loudly otherwise.
+            // Belt and braces: the `pr` step above already rejects anything that
+            // is not canonical digits. Kept because Number.parseInt takes the
+            // longest valid prefix, so "123abc" and "1e3" would coerce to 123 and
+            // 1 and sail past an isInteger check if that gate ever moved.
             const raw = (process.env.PR_NUMBER || "").trim();
             if (!/^[1-9][0-9]*$/.test(raw)) {
               core.setFailed(`Invalid PR number in PR_NUMBER: ${JSON.stringify(raw)}`);

--- a/.github/workflows/label-pr-on-approval.yml
+++ b/.github/workflows/label-pr-on-approval.yml
@@ -4,18 +4,22 @@ on:
     workflows: ["Maintenance: Listen PR review and label it"]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   label:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: write
 
     steps:
       - name: Download PR number artifact from upstream run
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-number-${{ github.event.workflow_run.id }}   # same unique name
           path: .
@@ -26,7 +30,7 @@ jobs:
         run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
 
       - name: Label when approved
-        uses: j-fulbright/label-when-approved-action@v1.2
+        uses: j-fulbright/label-when-approved-action@911c622c75f8ea99ee00cdd66e2cd888bac530c6 # v1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           label: 'Ready to merge'
@@ -37,11 +41,17 @@ jobs:
 
       - name: Remove review-related labels
         if: ${{ success() }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
-            const issue_number = ${{ steps.pr.outputs.number }};
+            const issue_number = Number.parseInt(process.env.PR_NUMBER || "", 10);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              core.setFailed("Invalid PR number in PR_NUMBER");
+              return;
+            }
             const labelsToRemove = ["Needs review", "Work in progress", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
 
             for (const name of labelsToRemove) {

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,4 +1,4 @@
-name: "Maintenance: Synhronize labels"
+name: "Maintenance: Synchronize labels"
 run-name: Sync Labels from YML on ${{ github.event_name }}
 
 on:
@@ -12,6 +12,9 @@ on:
     paths:
       - ".github/labels.yml"
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
     permissions:
@@ -24,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v6
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml


### PR DESCRIPTION
## What

Brings the four labeling workflows in line with `armbian/build`'s copies, which had already been hardened. **No logic changes** — same actions, same versions, same behaviour.

Noticed while porting this system to `armbian/ci` (armbian/ci#59): the two repos ran the same workflows, but this one had the older, looser variant.

## Changes

**Pin all 12 action references** to the same commit SHAs build uses. These run on `pull_request_target` with `pull-requests: write` and `issues: write`, so a moving tag is the exposure that matters here — a retagged upstream action would run with write scope against this repo. Same versions as before, now immutable.

**Fix a script injection** in `label-pr-on-approval.yml`:

```js
const issue_number = ${{ steps.pr.outputs.number }};
```

That is the Actions expression engine writing a value directly into JavaScript source. Now passed via `env` and parsed:

```js
const issue_number = Number.parseInt(process.env.PR_NUMBER || "", 10);
if (!Number.isInteger(issue_number) || issue_number <= 0) { core.setFailed(...); return; }
```

**Permissions**: add the default `permissions: contents: read` block that build and ci carry, and grant the approval job `actions: read` — it downloads an artifact from the upstream run and had been relying on the repository default.

## Not changed

Workflow `name:` fields are left alone. They surface as check names, and the listen / on-approval pair reference each other by name (`workflow_run.workflows`), so renaming means a coordinated change with a real chance of quietly breaking the chain. Verified that link still matches exactly.

The one exception is the `Synhronize` typo in the sync workflow's name, which nothing references.

After this, the only difference between these files and build's is the `name:` fields.

Signed-off-by: Igor Pecovnik <igor@armbian.com>