### PR TITLE
maintenance-update-readme: expand default repos (6 -> 15) + fix input default

### DIFF
--- a/.github/workflows/maintenance-update-readme.yml
+++ b/.github/workflows/maintenance-update-readme.yml
@@ -47,7 +47,7 @@ jobs:
       - id: set
         env:
           # Route the dispatch input through env (not inline ${{ }}) to avoid shell injection.
-          REPOS: ${{ github.event.inputs.repos || 'armbian/build,armbian/configng,armbian/ci,armbian/imager,armbian/documentation,armbian/distribution' }}
+          REPOS: ${{ github.event.inputs.repos || 'armbian/build,armbian/configng,armbian/ci,armbian/imager,armbian/documentation,armbian/distribution,armbian/actions,armbian/armbian.github.io,armbian/armbian-router,armbian/shallow,armbian/docker-armbian-build,armbian/autotests,armbian/sdk,armbian/hastebin-ansi,armbian/infra' }}
         run: |
           set -euo pipefail
           matrix="$(echo "$REPOS" | tr ',' '\n' | sed 's/[[:space:]]//g' | grep -v '^$' | jq -R . | jq -s -c .)"

--- a/.github/workflows/maintenance-update-readme.yml
+++ b/.github/workflows/maintenance-update-readme.yml
@@ -20,9 +20,9 @@ on:
   workflow_dispatch:
     inputs:
       repos:
-        description: "Comma-separated owner/repo targets (default: core repos)"
+        description: "Comma-separated owner/repo targets (leave empty for the full default set)"
         required: false
-        default: "armbian/build,armbian/configng,armbian/ci,armbian/imager,armbian/documentation,armbian/distribution"
+        default: ""
       model:
         description: "Claude model id"
         required: false


### PR DESCRIPTION
Two changes to the **Maintenance: Update README (AI)** workflow.

## 1. Expand the default target set (6 → 15)
Added: `actions`, `armbian.github.io`, `armbian-router`, `shallow`, `docker-armbian-build`, `autotests`, `sdk`, `hastebin-ansi`, `infra`.

Full set: build, configng, ci, imager, documentation, distribution, actions, armbian.github.io, armbian-router, shallow, docker-armbian-build, autotests, sdk, hastebin-ansi, infra.

Deliberately excluded: kernel forks, out-of-tree drivers (`*-dkms` etc.), firmware/blobs, and cache repos — the workflow overwrites `README.md` and would clobber their upstream READMEs.

## 2. Fix the stale `repos` dispatch-input default
The `workflow_dispatch` `repos` input still defaulted to the **old 6-repo** list, so:
- scheduled (cron) runs → empty input → used the 15-repo env fallback ✅
- **manual runs → pre-filled 6 repos → the `||` fallback never fired → only 6** ❌

Set the input default to **empty** (description updated). Now a blank manual run falls through to the same env fallback as the cron run, and the env `REPOS:` line is the single source of truth for the default set.

Validated: YAML parses; manual-empty / scheduled / env-fallback all resolve to the same 15 repos; a custom input still overrides.