### PR TITLE
nightly: build Ubuntu minimal for Khadas VIM1S and VIM4 on current

### DIFF
--- a/release-targets/targets-release-nightly.manual
+++ b/release-targets/targets-release-nightly.manual
@@ -61,3 +61,23 @@ minimal-cli-stable-debian-cloud-trixie:
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-qcow2" }
     - { BOARD: uefi-arm64, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
     - { BOARD: uefi-x86, BRANCH: cloud, ENABLE_EXTENSIONS: "image-output-vhdx" }
+
+# Ubuntu minimal CLI for Khadas VIM1S / VIM4 on mainline (current).
+# Both boards are in targets-release-nightly.blacklist so the auto-generated
+# section skips them. Note that removing them from the blacklist would NOT
+# produce this image: they are fast-HDMI boards, and that bucket only gets
+# Debian minimal + Ubuntu GNOME desktop. Ubuntu minimal CLI is emitted for
+# headless boards only, hence this explicit target.
+nightly-ubuntu-minimal-khadas-vims:
+  enabled: yes
+  configs: [ armbian-images ]
+  pipeline:
+    gha: *armbian-gha
+  build-image: "yes"
+  vars:
+    RELEASE: UBUNTU
+    BUILD_MINIMAL: "yes"
+    BUILD_DESKTOP: "no"
+  items:
+    - { BOARD: khadas-vim1s, BRANCH: current, ENABLE_EXTENSIONS: "image-output-oowow" }
+    - { BOARD: khadas-vim4, BRANCH: current, ENABLE_EXTENSIONS: "image-output-oowow" }


### PR DESCRIPTION
TL;DR — Khadas VIM1S and VIM4 ship nightly only on the legacy 5.15 vendor kernel. This adds a nightly **Ubuntu minimal CLI** target on `current` (mainline 7.1), so meson-s4t7 mainline gets continuous image coverage.

```yaml
nightly-ubuntu-minimal-khadas-vims:
  enabled: yes
  configs: [ armbian-images ]
  vars:
    RELEASE: UBUNTU
    BUILD_MINIMAL: "yes"
    BUILD_DESKTOP: "no"
  items:
    - { BOARD: khadas-vim1s, BRANCH: current, ENABLE_EXTENSIONS: "image-output-oowow" }
    - { BOARD: khadas-vim4, BRANCH: current, ENABLE_EXTENSIONS: "image-output-oowow" }
```

### Why `.manual` and not just dropping them from the blacklist

Both boards sit in `targets-release-nightly.blacklist`, and its header invites removal — but that alone would not produce this image. In `generate_nightly_yaml()` a fast-HDMI board (arm64 + video, which both VIMs are) only ever gets:

- `nightly-forky-all` — Debian minimal CLI
- `nightly-resolute-gnome` — Ubuntu **GNOME desktop**

`nightly-resolute-minimal` takes `*nightly-headless` only, so Ubuntu minimal is never emitted for these boards. Hence an explicit target — the same mechanism `uefi-arm64` / `uefi-x86` already use, which are likewise blacklisted yet get explicit cloud targets from `.manual`.

`image-output-oowow` is spelled out on the items because `targets-extensions.map` is applied to the auto-generated section, not to `.manual` content.

### Verified

Ran `scripts/generate_targets.py` against `image-info.json`, and diffed against a baseline run on `main`:

- Target lands inside `targets:` at the right indent; `RELEASE: UBUNTU` resolves to `resolute`; YAML parses and `*armbian-gha` resolves
- Both boards appear in exactly one nightly target — no duplicate builds
- `targets-release-standard-support.yaml`, `targets-release-apps.yaml`, `targets-release-community-maintained.yaml` and `exposed.map` are **byte-identical** to baseline; only the nightly file changes, by exactly this block

Both boards declare `KERNEL_TARGET="legacy,current"`, and `current` on meson-s4t7 is mainline 7.1 with an existing patch dir, so the branch is real. Net effect is two extra nightly images.
