### PR TITLE
release-targets: NanoPi M3 and Fire3 reuse the NanoPC-T3 Plus images

### DIFF
--- a/release-targets/reusable.yml
+++ b/release-targets/reusable.yml
@@ -291,3 +291,27 @@ boards:
     uses: "nanopct6-lts"
     branch: "current"
     file_extension: "img.xz"
+
+  # NanoPi M3 and NanoPi Fire3 are the same Nexell S5P6818 octa-core SoC as the
+  # NanoPC-T3 Plus and were built from the same s5p6818 family before it was
+  # retired, so they take that board's images rather than carrying their own
+  # build targets.
+  - board_slug: "nanopim3"
+    board_name: "NanoPi M3"
+    board_vendor: "friendlyelec"
+    board_support: "conf"
+
+    # The magic: reuse artifact set
+    uses: "nanopct3plus"
+    branch: "current"
+    file_extension: "img.xz"
+
+  - board_slug: "nanopifire3"
+    board_name: "NanoPi Fire3"
+    board_vendor: "friendlyelec"
+    board_support: "conf"
+
+    # The magic: reuse artifact set
+    uses: "nanopct3plus"
+    branch: "current"
+    file_extension: "img.xz"


### PR DESCRIPTION
Adds `nanopim3` and `nanopifire3` as virtual boards in `release-targets/reusable.yml`, both reusing `nanopct3plus`.

Both are the same **Nexell S5P6818** octa-core SoC as the NanoPC-T3 Plus, and both were built from the same `s5p6818` family until it was retired in `ccf17a20e` ("Purge `s5p6818` board family"). So they can take that board's images rather than carrying build targets of their own.

Board names taken from the original configs at `ccf17a20e^` rather than invented — `BOARD_NAME="NanoPi M3"` and `BOARD_NAME="NanoPi Fire3"`.

Modelled on the `nanopct6-plus` entry directly above: same vendor, a variant reusing a sibling's artifact set, `branch: current`, `file_extension: img.xz`, and `board_introduced` left off (the generator defaults it to `''` at `generate-armbian-images-json.sh:141`, and the sibling entry omits it too).

## :warning: Do not merge before the nanopct3plus build PR

The file's own rules say *"The 'uses' board MUST exist in the actual build/firmware infrastructure"*. Right now it does not:

- `config/boards/nanopct3plus.conf` exists only on the `resurrect/nanopct3plus` branch in `armbian/build` — `git ls-tree origin/main` has no match.

Merging this first would produce two virtual boards pointing at a base board with no artifacts. **This needs to land after the nanopct3plus PR**, which is still in progress.

## Related

Board photos come from #443 (`nanopim3.png`, `nanopifire3.png`, `nanopct3plus.png`) — also not yet on `main`. Ideally #443 merges first, or alongside, so the downloads UI has renders for these entries.

## Verification

- YAML parses; 18 virtual boards total, no duplicate `board_slug`.
- All required fields present on both entries; `board_support: "conf"` is one of the four accepted values (`conf`/`csc`/`wip`/`tvb`).
- `friendlyelec` is an established `board_vendor` in this file (used by `nanopct6-plus`).