### PR TITLE
fix: stop dropping releases from `base-files.json` on transient mirror timeouts

### DIFF
--- a/scripts/generate-base-files-info-json.py
+++ b/scripts/generate-base-files-info-json.py
@@ -281,7 +281,13 @@ if __name__ == "__main__":
     releases += [ 'ubuntu/jammy', 'ubuntu/noble', 'ubuntu/plucky', 'ubuntu/questing', 'ubuntu/resolute' ]
     # Add -updates repos for LTS releases to get latest security updates
     releases += [ 'ubuntu/jammy-updates', 'ubuntu/noble-updates' ]
-    release_hash = {}
+    # Seed from the currently-published index (wanted releases only) so a transient fetch failure keeps the prior entry
+    wanted_releases = {wanted.split('/', 1)[1] for wanted in releases}
+    try:
+        published = requests.get("https://github.armbian.com/base-files.json", timeout=30).json()
+    except (requests.exceptions.RequestException, ValueError):
+        published = {}
+    release_hash = {name: info for name, info in published.items() if name in wanted_releases}
     for release in releases:
         distro, release = release.split('/')
         packages = {}

--- a/scripts/generate-base-files-info-json.py
+++ b/scripts/generate-base-files-info-json.py
@@ -284,7 +284,9 @@ if __name__ == "__main__":
     # Seed from the currently-published index (wanted releases only) so a transient fetch failure keeps the prior entry
     wanted_releases = {wanted.split('/', 1)[1] for wanted in releases}
     try:
-        published = requests.get("https://github.armbian.com/base-files.json", timeout=30).json()
+        response = requests.get("https://github.armbian.com/base-files.json", timeout=30)
+        response.raise_for_status()
+        published = response.json()
     except (requests.exceptions.RequestException, ValueError):
         published = {}
     release_hash = {name: info for name, info in published.items() if name in wanted_releases}


### PR DESCRIPTION
The generator rewrites `base-files.json` from scratch each run, and a single `requests.get(timeout=30)` failure (from https://github.com/armbian/armbian.github.io/commit/d7787cd0128b087c8a9efe13c82b2469c6f85433) makes that release vanish from the published index.

You can see `resolute` failed in this log and was thus missing from https://github.armbian.com/base-files.json: https://github.com/armbian/armbian.github.io/actions/runs/34578429562/job/103196150483
```
WARNING: skipping release ubuntu/resolute: HTTPConnectionPool(host='archive.ubuntu.com', port=80): Read timed out. (read timeout=30)
```

Downstream this breaks any build pinning the dropped release, ie `RELEASE=resolute` fails in `artifact-armbian-base-files` with `found_package_filename is null`

This change seeds `release_hash` from the currently published `base-files.json` before the loop, so a release that transiently fails to fetch keeps its prior entry instead of disappearing. Seeding is filtered by the wanted `releases` list, so retiring a release is just removing it there