### PR TITLE
data: fail closed when a mirror is unreachable, not silently short

### DIFF
--- a/.github/workflows/data-update-base-files-info.yml
+++ b/.github/workflows/data-update-base-files-info.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: '45 3 * * *'
   workflow_dispatch:
+    inputs:
+      allow_removals:
+        description: "Publish even if releases/architectures disappear (use when upstream really dropped one)"
+        type: boolean
+        default: false
   repository_dispatch:
     types: ["Data: Update base-files info"]
 
@@ -39,6 +44,8 @@ jobs:
           ./scripts/generate-base-files-info-json.py base-files
       # Step 5: Commit changes if any
       - name: Commit changes if any
+        env:
+          ALLOW_REMOVALS: ${{ inputs.allow_removals || false }}
         run: |
           set -euo pipefail
 
@@ -49,6 +56,39 @@ jobs:
           git checkout data
 
           mkdir -p data
+
+          # Backstop. The generator already refuses to write a partial index
+          # when a mirror is unreachable; this catches anything that gets past
+          # it, because every build reads this file and one missing entry
+          # breaks every build of that release (armbian/build#10680).
+          if [ -f data/base-files.json ]; then
+            lost="$(jq -r --slurpfile new base-files.json '
+              . as $old
+              | $new[0] as $n
+              | [ $old
+                  | to_entries[]
+                  | .key as $rel
+                  | if ($n | has($rel) | not)
+                    then "release \($rel)"
+                    else ( .value | keys[] as $arch
+                           | select($n[$rel] | has($arch) | not)
+                           | "\($rel) (\($arch))" )
+                    end
+                ]
+              | .[]' data/base-files.json)"
+            if [ -n "$lost" ]; then
+              echo "::error::The generated index drops entries that are currently published:"
+              echo "$lost" | sed 's/^/  - /'
+              if [ "${ALLOW_REMOVALS}" = "true" ]; then
+                echo "::warning::allow_removals was set - publishing anyway"
+              else
+                echo "Refusing to publish. The currently published index stays in place."
+                echo "If upstream really dropped these, re-run this workflow with allow_removals=true."
+                exit 1
+              fi
+            fi
+          fi
+
           mv base-files.json data/base-files.json
 
           git add data/base-files.json

--- a/scripts/generate-base-files-info-json.py
+++ b/scripts/generate-base-files-info-json.py
@@ -4,11 +4,59 @@
 
 import os
 import requests
+import sys
+import time
 from pathlib import Path
 import json
 import re
 import gzip
 from urllib.parse import urljoin
+
+
+class UpstreamGone(Exception):
+    """The archive answered, and the thing genuinely is not published."""
+
+
+class UpstreamUnreachable(Exception):
+    """The archive did not answer. Says nothing about what it publishes."""
+
+
+HTTP_ATTEMPTS = 4
+HTTP_TIMEOUT = 60
+
+
+def http_get(url, timeout=HTTP_TIMEOUT):
+    """
+    GET with retries, separating "not published" from "could not ask".
+
+    A 404 is an answer: the release or architecture is not there, and the
+    caller may legitimately skip it. A timeout, a connection error or a 5xx
+    is not an answer - treating it as one is what silently dropped Ubuntu
+    resolute out of the published index (armbian/build#10680) and broke every
+    build of that release until the next run happened to succeed.
+    """
+    last = None
+    for attempt in range(1, HTTP_ATTEMPTS + 1):
+        try:
+            response = requests.get(url, timeout=timeout)
+        except requests.exceptions.RequestException as e:
+            last = e
+        else:
+            if response.status_code == 404:
+                raise UpstreamGone(f"404 Not Found: {url}")
+            if response.status_code < 500:
+                response.raise_for_status()
+                return response
+            last = requests.exceptions.HTTPError(
+                f"{response.status_code} {response.reason}: {url}")
+
+        if attempt < HTTP_ATTEMPTS:
+            delay = 3 ** attempt
+            print(f"WARNING: {url}: {last}; retrying in {delay}s "
+                  f"({attempt}/{HTTP_ATTEMPTS - 1})", flush=True)
+            time.sleep(delay)
+
+    raise UpstreamUnreachable(f"{url}: {last}")
 
 def get_debian_release_names(cache_dir="./debian_cache"):
     """
@@ -28,8 +76,7 @@ def get_debian_release_names(cache_dir="./debian_cache"):
             readme_content = f.read()
     else:
         print("Downloading README...")
-        response = requests.get(readme_url, timeout=30)
-        response.raise_for_status()
+        response = http_get(readme_url)
         readme_content = response.text
 
         # Save to cache
@@ -74,8 +121,7 @@ def get_debian_architectures(distro, release_name, cache_dir="./debian_cache"):
             inrelease_content = f.read()
     else:
         #print(f"Downloading InRelease for {release_name}...")
-        response = requests.get(inrelease_url, timeout=30)
-        response.raise_for_status()
+        response = http_get(inrelease_url)
         inrelease_content = response.text
 
         # Save to cache
@@ -126,8 +172,7 @@ def get_debian_srcpkg_architecture(distro, release_name, package_name, cache_dir
         print(f"Using cached Sources.gz: {sources_path}")
     else:
         print(f"Downloading Sources.gz for {release_name}...")
-        response = requests.get(sources_url, timeout=30)
-        response.raise_for_status()
+        response = http_get(sources_url)
 
         # Save to cache
         with open(sources_path, 'wb') as f:
@@ -208,8 +253,7 @@ def get_debian_binary_package_filename(distro, release_name, package_name, archi
         print(f"Using cached Packages.gz: {packages_path}")
     else:
         print(f"Downloading Packages.gz for {release_name} ({architecture})...")
-        response = requests.get(packages_url, timeout=30)
-        response.raise_for_status()
+        response = http_get(packages_url)
 
         # Save to cache
         with open(packages_path, 'wb') as f:
@@ -282,13 +326,16 @@ if __name__ == "__main__":
     # Add -updates repos for LTS releases to get latest security updates
     releases += [ 'ubuntu/jammy-updates', 'ubuntu/noble-updates' ]
     release_hash = {}
+    unreachable = []
     for release in releases:
         distro, release = release.split('/')
         packages = {}
 
-        # A release-level fetch failure (Sources/InRelease 404 or a network
-        # error) should drop just that release with a warning, not abort the
-        # whole index update.
+        # A release that upstream genuinely does not publish (404) or that has
+        # no base-files source package is dropped with a warning. A release we
+        # could not *ask* about is recorded and fails the run at the end: the
+        # published index is what every build reads, and quietly shipping it
+        # one release short breaks all of them.
         try:
             pkg_architecture = get_debian_srcpkg_architecture(distro, release, "base-files")
 
@@ -299,8 +346,12 @@ if __name__ == "__main__":
                 architectures = get_debian_architectures(distro, release)
             else:
                 architectures = arch_list
-        except (requests.exceptions.RequestException, FileNotFoundError) as e:
+        except (UpstreamGone, FileNotFoundError) as e:
             print(f"WARNING: skipping release {distro}/{release}: {e}")
+            continue
+        except UpstreamUnreachable as e:
+            print(f"ERROR: could not reach upstream for release {distro}/{release}: {e}")
+            unreachable.append(f"{distro}/{release}")
             continue
 
         # Get binary package filename
@@ -315,11 +366,25 @@ if __name__ == "__main__":
         for architecture in architectures:
             try:
                 binary_filename = get_debian_binary_package_filename(distro, release, "base-files", architecture)
-            except requests.exceptions.RequestException as e:
+            except UpstreamGone as e:
                 print(f"WARNING: skipping {distro}/{release} ({architecture}): {e}")
+                continue
+            except UpstreamUnreachable as e:
+                print(f"ERROR: could not reach upstream for {distro}/{release} ({architecture}): {e}")
+                unreachable.append(f"{distro}/{release} ({architecture})")
                 continue
             packages[architecture] = binary_filename
         release_hash[release] = packages
+
+    # Fail closed. Writing a half-built index is worse than writing nothing:
+    # the previous good one stays published and builds keep working.
+    if unreachable:
+        print("\nERROR: upstream was unreachable for:", file=sys.stderr)
+        for item in unreachable:
+            print(f"  - {item}", file=sys.stderr)
+        print("Refusing to write a partial index; the published one stays in "
+              "place. Re-run once upstream is healthy.", file=sys.stderr)
+        sys.exit(1)
 
     json_content = json.dumps(release_hash)
     print(json_content)

--- a/scripts/generate-base-files-info-json.py
+++ b/scripts/generate-base-files-info-json.py
@@ -44,9 +44,11 @@ def http_get(url, timeout=HTTP_TIMEOUT):
         else:
             if response.status_code == 404:
                 raise UpstreamGone(f"404 Not Found: {url}")
-            if response.status_code < 500:
-                response.raise_for_status()
+            if response.ok:
                 return response
+            # Everything else - 429 and 403 from a rate-limiting or unhappy
+            # mirror, any 5xx - is retried and then reported as unreachable.
+            # Only a 404 is taken as a statement about what is published.
             last = requests.exceptions.HTTPError(
                 f"{response.status_code} {response.reason}: {url}")
 

--- a/scripts/generate-base-files-info-json.py
+++ b/scripts/generate-base-files-info-json.py
@@ -23,6 +23,7 @@ class UpstreamUnreachable(Exception):
 
 HTTP_ATTEMPTS = 4
 HTTP_TIMEOUT = 60
+PUBLISHED_INDEX_URL = "https://github.armbian.com/base-files.json"
 
 
 def http_get(url, timeout=HTTP_TIMEOUT):
@@ -315,8 +316,7 @@ def synthesize_binary_package_filename(package_info):
 
     return filename
 
-# Example usage:
-if __name__ == "__main__":
+def main():
     releases = get_debian_release_names()
     if('debian/rc-buggy' in releases):
         releases.remove('debian/rc-buggy')
@@ -327,11 +327,28 @@ if __name__ == "__main__":
     releases += [ 'ubuntu/jammy', 'ubuntu/noble', 'ubuntu/plucky', 'ubuntu/questing', 'ubuntu/resolute' ]
     # Add -updates repos for LTS releases to get latest security updates
     releases += [ 'ubuntu/jammy-updates', 'ubuntu/noble-updates' ]
+    # Seed from the currently published index, restricted to the releases we
+    # still want, so anything we cannot reach this run keeps the value it
+    # already has instead of vanishing. Approach from @silvervest in #446.
+    wanted_releases = {wanted.split('/', 1)[1] for wanted in releases}
+    try:
+        published = http_get(PUBLISHED_INDEX_URL).json()
+        if not isinstance(published, dict):
+            raise ValueError("published index is not an object")
+    except (UpstreamGone, UpstreamUnreachable, ValueError) as e:
+        print(f"WARNING: could not read the published index ({e}); "
+              "nothing to fall back on this run")
+        published = {}
+    published = {name: info for name, info in published.items()
+                 if name in wanted_releases and isinstance(info, dict)}
+
     release_hash = {}
     unreachable = []
+    carried = []
     for release in releases:
         distro, release = release.split('/')
         packages = {}
+        seed = published.get(release, {})
 
         # A release that upstream genuinely does not publish (404) or that has
         # no base-files source package is dropped with a warning. A release we
@@ -352,8 +369,17 @@ if __name__ == "__main__":
             print(f"WARNING: skipping release {distro}/{release}: {e}")
             continue
         except UpstreamUnreachable as e:
-            print(f"ERROR: could not reach upstream for release {distro}/{release}: {e}")
-            unreachable.append(f"{distro}/{release}")
+            # Unreachable, not gone. Keep what is already published rather
+            # than dropping the release; only a release we have never
+            # published has nothing to fall back on.
+            if seed:
+                release_hash[release] = seed
+                carried.append(f"{distro}/{release}")
+                print(f"WARNING: could not reach upstream for release "
+                      f"{distro}/{release}: {e}; keeping the published entry")
+            else:
+                print(f"ERROR: could not reach upstream for release {distro}/{release}: {e}")
+                unreachable.append(f"{distro}/{release}")
             continue
 
         # Get binary package filename
@@ -369,17 +395,35 @@ if __name__ == "__main__":
             try:
                 binary_filename = get_debian_binary_package_filename(distro, release, "base-files", architecture)
             except UpstreamGone as e:
+                # Genuinely not published any more - do NOT carry the old
+                # value forward, or a retired architecture would live on in
+                # the index for ever.
                 print(f"WARNING: skipping {distro}/{release} ({architecture}): {e}")
                 continue
             except UpstreamUnreachable as e:
-                print(f"ERROR: could not reach upstream for {distro}/{release} ({architecture}): {e}")
-                unreachable.append(f"{distro}/{release} ({architecture})")
+                if architecture in seed:
+                    packages[architecture] = seed[architecture]
+                    carried.append(f"{distro}/{release} ({architecture})")
+                    print(f"WARNING: could not reach upstream for "
+                          f"{distro}/{release} ({architecture}): {e}; "
+                          "keeping the published entry")
+                else:
+                    print(f"ERROR: could not reach upstream for {distro}/{release} ({architecture}): {e}")
+                    unreachable.append(f"{distro}/{release} ({architecture})")
                 continue
             packages[architecture] = binary_filename
+        # Assigned wholesale, so a seeded entry only survives through the
+        # per-architecture carry-forward above: seeding alone does not protect
+        # against a single architecture failing while the release is reachable.
         release_hash[release] = packages
 
-    # Fail closed. Writing a half-built index is worse than writing nothing:
-    # the previous good one stays published and builds keep working.
+    if carried:
+        print(f"\n::warning::Kept the published entry for {len(carried)} item(s) "
+              f"upstream could not be reached for: {', '.join(carried)}")
+
+    # Fail closed on anything with nothing to fall back on. Writing a
+    # half-built index is worse than writing nothing: the previous good one
+    # stays published and builds keep working.
     if unreachable:
         print("\nERROR: upstream was unreachable for:", file=sys.stderr)
         for item in unreachable:
@@ -393,3 +437,7 @@ if __name__ == "__main__":
     json_file_name = "base-files.json"
     with open(json_file_name, "w") as outfile:
         outfile.write(json_content)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes armbian/build#10680

## What happened

The nightly run on 2026-09-11 at 08:17 UTC reported **success** while silently dropping Ubuntu resolute from the published index:

```
WARNING: skipping release ubuntu/resolute: HTTPConnectionPool(host='archive.ubuntu.com', port=80): Read timed out. (read timeout=30)
```

The workflow committed that result. Every resolute build then failed in `apt_find_upstream_package_version_and_download_url` with a null `base-files` filename, because `.resolute.arm64` no longer existed.

The same run also lost entries nobody filed a bug for:

| Release | Lost | Effect |
| --- | --- | --- |
| resolute | the whole release | all builds |
| questing | `amd64`, `amd64v3` | x86_64 builds |
| plucky | `amd64` | x86_64 builds |
| jammy-updates | `amd64` | x86_64 builds |
| jammy / noble / noble-updates | `i386` | minor |

Nothing was wrong upstream. Re-running the workflow unchanged restored every entry, which is what makes this a process bug rather than an archive bug.

## Cause

`get_debian_architectures` fetches `archive.ubuntu.com/ubuntu/dists/<release>/InRelease`, and the release-level handler caught `requests.exceptions.RequestException` alongside `FileNotFoundError` and `continue`d. So "the archive did not answer" and "the archive says this is not published" were the same code path. A single 30-second timeout was indistinguishable from a release being retired.

Supersedes #446, whose carry-forward approach is folded in here (@silvervest credited as co-author). That PR spotted the same root cause first, from the same log line.

## Change

**Generator** — all four fetches now go through an `http_get` that retries with backoff (4 attempts, 60s timeout), then separates the two cases:

- `404` → `UpstreamGone`. A real answer; warn and skip, as before. This keeps the deliberate tolerance for an architecture mid-promotion between debian-ports and the main archive.
- timeout / connection error / 5xx → `UpstreamUnreachable`. Not an answer. Collected, and turned into a non-zero exit at the end, **before anything is written**. No partial index is produced, so the previously published one stays in place and builds keep working.

**Carry-forward (from #446)** — `release_hash` is seeded from the published index, restricted to the releases still wanted, and used as the fallback when upstream could not be reached. Applied at **both** the release and the architecture level: `release_hash[release] = packages` assigns wholesale, so seeding at release level alone is silently overwritten whenever the release is reachable but one architecture is not — which is how the same run also lost `questing` amd64/amd64v3, `plucky` amd64 and `jammy-updates` amd64. A 404 still drops the entry, so a retired release or architecture does not live on for ever.

Fail-closed now applies only to what has nothing to fall back on: a release never published before, or a run that could not read the published index at all. Anything carried forward is reported as a GitHub `::warning`, so a quietly degrading mirror stays visible.

**Workflow** — a backstop for anything that gets past that. Before committing, the generated index is compared against the currently published one; any release or architecture that disappeared aborts the publish with the list. A genuine upstream removal can still be published by re-running with `allow_removals=true`.

## Testing

- `http_get` classification: 404 → `UpstreamGone`, unroutable host → `UpstreamUnreachable` after retrying, healthy URL → 200.
- The workflow guard was extracted from the YAML and executed against the real before/after JSONs from this incident: the broken index is rejected listing exactly the 9 lost entries, the recovery direction passes, an unchanged index passes, and `allow_removals=true` overrides.
- `main()` was extracted from the `__main__` block so the carry-forward paths can be driven directly. Six cases pass: healthy run; release unreachable **with** a seed (carried, exit 0); architecture unreachable with a seed (carried — the case seeding at release level alone misses); a 404 architecture staying dropped rather than resurrected; release unreachable with **no** seed (fail closed, nothing written); architecture unreachable with no seed (fail closed).
- Full generator run end to end: exit 0, no warnings, complete index including `resolute` with all 8 architectures, and byte-identical coverage to the current published index — `.resolute.arm64 = base-files_14ubuntu6_arm64.deb`.

## Note on scope

A bad upstream day now refreshes everything reachable, carries forward only what it could not reach, and says so loudly. It fails the run outright only when there is nothing to fall back on. What it does not do is paper over a *persistent* upstream problem indefinitely — a release stuck on carried-forward values keeps emitting the warning every run, which is the signal to go look.
