### PR TITLE
generate_targets: classify S5P6818 as slow HW (XFCE, not GNOME)

### DIFF
--- a/scripts/generate_targets.py
+++ b/scripts/generate_targets.py
@@ -502,6 +502,13 @@ def is_fast_hardware(entry):
     if board_family == 'imx93':
         return False
 
+    # Nexell S5P6818 (NanoPi M3 / NanoPC-T3+ / NanoPi Fire3) has a Mali-400
+    # GPU that is GLES2-only — no OpenGL ES 3.0, which GNOME/mutter requires,
+    # so the shell falls back to software rendering (and it is 1 GiB). Classify
+    # as slow to get XFCE instead of GNOME.
+    if board_family == 's5p6818':
+        return False
+
     # Rockchip RK3328, RK3399 and RK3399PRO are slow
     if boot_soc in ['rk3328', 'rk3399', 'rk3399pro']:
         return False


### PR DESCRIPTION
### What

Classify the Nexell **S5P6818** boardfamily (NanoPi M3 / NanoPC-T3+ / NanoPi Fire3) as *slow* hardware in `is_fast_hardware()`, so the build-list generator produces **XFCE** desktop images instead of **GNOME**.

### Why

These boards are arm64, so the generator's default puts them in the "fast HDMI → GNOME" bucket. But their **Mali-400 GPU is GLES2-only** — no OpenGL ES 3.0, which GNOME/mutter requires. mutter therefore falls back to software rendering, which on this 1 GiB SoC is:

- **broken** — `gnome-shell` SIGSEGVs every frame in Mesa's software EGL `swap_buffers_with_damage` path (NULL function pointer), and
- **far too slow** even if that were fixed.

This is the same reasoning as the **i.MX93** exception immediately above it (2D-only GPU → software only → slow/XFCE). XFCE (X11 + glamor on GLES2) is the appropriate desktop for this class.

Context: S5P6818 mainline bring-up is armbian/build#10674 (branch `resurrect/nanopct3plus`); `FULL_DESKTOP` was already dropped there, and this is the build-list-level counterpart.

Signed-off-by: Igor Pecovnik <igor@armbian.com>